### PR TITLE
Slamd refactor tests

### DIFF
--- a/slamd/common/error_handling.py
+++ b/slamd/common/error_handling.py
@@ -2,8 +2,8 @@ from flask import render_template
 
 
 def handle_404(err):
-    return render_template('404.html')
+    return render_template('404.html'), 404
 
 
 def handle_400(err):
-    return render_template('400.html')
+    return render_template('400.html'), 400

--- a/slamd/materials/processing/models/admixture.py
+++ b/slamd/materials/processing/models/admixture.py
@@ -3,7 +3,8 @@ from slamd.materials.processing.models.material import Material
 
 class Admixture(Material):
 
-    def __init__(self, composition=None, type=None):
-        super().__init__()
+    def __init__(self, name='', type='', costs=None, composition=None, admixture_type=None, additional_properties=None):
+        super().__init__(name=name, type=type, costs=None)
         self.composition = composition
-        self.type = type
+        self.admixture_type = admixture_type
+        self.additional_properties = additional_properties

--- a/slamd/materials/processing/models/admixture.py
+++ b/slamd/materials/processing/models/admixture.py
@@ -4,7 +4,7 @@ from slamd.materials.processing.models.material import Material
 class Admixture(Material):
 
     def __init__(self, name='', type='', costs=None, composition=None, admixture_type=None, additional_properties=None):
-        super().__init__(name=name, type=type, costs=None)
+        super().__init__(name=name, type=type, costs=costs,
+                         additional_properties=additional_properties)
         self.composition = composition
         self.admixture_type = admixture_type
-        self.additional_properties = additional_properties

--- a/slamd/materials/processing/models/aggregates.py
+++ b/slamd/materials/processing/models/aggregates.py
@@ -3,9 +3,10 @@ from slamd.materials.processing.models.material import Material
 
 class Aggregates(Material):
 
-    def __init__(self, composition=None):
-        super().__init__()
+    def __init__(self, name='', type='', costs=None, composition=None, additional_properties=None):
+        super().__init__(name=name, type=type, costs=None)
         self.composition = composition
+        self.additional_properties = additional_properties
 
 
 class Composition:

--- a/slamd/materials/processing/models/aggregates.py
+++ b/slamd/materials/processing/models/aggregates.py
@@ -4,9 +4,9 @@ from slamd.materials.processing.models.material import Material
 class Aggregates(Material):
 
     def __init__(self, name='', type='', costs=None, composition=None, additional_properties=None):
-        super().__init__(name=name, type=type, costs=None)
+        super().__init__(name=name, type=type, costs=costs,
+                         additional_properties=additional_properties)
         self.composition = composition
-        self.additional_properties = additional_properties
 
 
 class Composition:

--- a/slamd/materials/processing/models/custom.py
+++ b/slamd/materials/processing/models/custom.py
@@ -4,7 +4,7 @@ from slamd.materials.processing.models.material import Material
 class Custom(Material):
 
     def __init__(self, name='', type='', costs=None, custom_name=None, custom_value=None, additional_properties=None):
-        super().__init__(name=name, type=type, costs=None)
+        super().__init__(name=name, type=type, costs=costs,
+                         additional_properties=additional_properties)
         self.custom_name = custom_name
         self.custom_value = custom_value
-        self.additional_properties = additional_properties

--- a/slamd/materials/processing/models/custom.py
+++ b/slamd/materials/processing/models/custom.py
@@ -3,7 +3,8 @@ from slamd.materials.processing.models.material import Material
 
 class Custom(Material):
 
-    def __init__(self, name=None, value=None):
-        super().__init__()
-        self.name = name
-        self.value = value
+    def __init__(self, name='', type='', costs=None, custom_name=None, custom_value=None, additional_properties=None):
+        super().__init__(name=name, type=type, costs=None)
+        self.custom_name = custom_name
+        self.custom_value = custom_value
+        self.additional_properties = additional_properties

--- a/slamd/materials/processing/models/liquid.py
+++ b/slamd/materials/processing/models/liquid.py
@@ -4,9 +4,9 @@ from slamd.materials.processing.models.material import Material
 class Liquid(Material):
 
     def __init__(self, name='', type='', costs=None, composition=None, additional_properties=None):
-        super().__init__(name=name, type=type, costs=None)
+        super().__init__(name=name, type=type, costs=costs,
+                         additional_properties=additional_properties)
         self.composition = composition
-        self.additional_properties = additional_properties
 
 
 class Composition:

--- a/slamd/materials/processing/models/liquid.py
+++ b/slamd/materials/processing/models/liquid.py
@@ -3,9 +3,10 @@ from slamd.materials.processing.models.material import Material
 
 class Liquid(Material):
 
-    def __init__(self, composition=None):
-        super().__init__()
+    def __init__(self, name='', type='', costs=None, composition=None, additional_properties=None):
+        super().__init__(name=name, type=type, costs=None)
         self.composition = composition
+        self.additional_properties = additional_properties
 
 
 class Composition:

--- a/slamd/materials/processing/models/powder.py
+++ b/slamd/materials/processing/models/powder.py
@@ -3,10 +3,11 @@ from slamd.materials.processing.models.material import Material
 
 class Powder(Material):
 
-    def __init__(self, composition=None, structure=None):
-        super().__init__()
+    def __init__(self, name='', type='', costs=None, composition=None, structure=None, additional_properties=None):
+        super().__init__(name=name, type=type, costs=costs)
         self.structure = structure
         self.composition = composition
+        self.additional_properties = additional_properties
 
 
 class Composition:

--- a/slamd/materials/processing/models/powder.py
+++ b/slamd/materials/processing/models/powder.py
@@ -4,10 +4,10 @@ from slamd.materials.processing.models.material import Material
 class Powder(Material):
 
     def __init__(self, name='', type='', costs=None, composition=None, structure=None, additional_properties=None):
-        super().__init__(name=name, type=type, costs=costs)
+        super().__init__(name=name, type=type, costs=costs,
+                         additional_properties=additional_properties)
         self.structure = structure
         self.composition = composition
-        self.additional_properties = additional_properties
 
 
 class Composition:

--- a/slamd/materials/processing/models/process.py
+++ b/slamd/materials/processing/models/process.py
@@ -3,8 +3,9 @@ from slamd.materials.processing.models.material import Material
 
 class Process(Material):
 
-    def __init__(self, duration=None, temperature=None, relative_humidity=None):
-        super().__init__()
+    def __init__(self, name='', type='', costs=None, duration=None, temperature=None, relative_humidity=None, additional_properties=None):
+        super().__init__(name=name, type=type, costs=None)
         self.duration = duration
         self.temperature = temperature
         self.relative_humidity = relative_humidity
+        self.additional_properties = additional_properties

--- a/slamd/materials/processing/models/process.py
+++ b/slamd/materials/processing/models/process.py
@@ -4,8 +4,8 @@ from slamd.materials.processing.models.material import Material
 class Process(Material):
 
     def __init__(self, name='', type='', costs=None, duration=None, temperature=None, relative_humidity=None, additional_properties=None):
-        super().__init__(name=name, type=type, costs=None)
+        super().__init__(name=name, type=type, costs=costs,
+                         additional_properties=additional_properties)
         self.duration = duration
         self.temperature = temperature
         self.relative_humidity = relative_humidity
-        self.additional_properties = additional_properties

--- a/slamd/materials/processing/strategies/admixture_strategy.py
+++ b/slamd/materials/processing/strategies/admixture_strategy.py
@@ -24,6 +24,6 @@ class AdmixtureStrategy(BaseMaterialStrategy):
 
         MaterialsPersistence.save('admixture', admixture)
 
-    def _gather_composition_information(self, admixture):
-        return [self._include('Composition', admixture.composition),
-                self._include('Type', admixture.admixture_type)]
+    def gather_composition_information(self, admixture):
+        return [self.include('Composition', admixture.composition),
+                self.include('Type', admixture.admixture_type)]

--- a/slamd/materials/processing/strategies/admixture_strategy.py
+++ b/slamd/materials/processing/strategies/admixture_strategy.py
@@ -1,4 +1,3 @@
-from slamd.materials.processing.materials_persistence import MaterialsPersistence
 from slamd.materials.processing.models.admixture import Admixture
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -15,7 +14,7 @@ class AdmixtureStrategy(BaseMaterialStrategy):
             additional_properties=additional_properties
         )
 
-        MaterialsPersistence.save('admixture', admixture)
+        self.save_material(admixture)
 
     def gather_composition_information(self, admixture):
         return [self.include('Composition', admixture.composition),

--- a/slamd/materials/processing/strategies/admixture_strategy.py
+++ b/slamd/materials/processing/strategies/admixture_strategy.py
@@ -1,5 +1,4 @@
 from slamd.materials.processing.materials_persistence import MaterialsPersistence
-from slamd.materials.processing.models.material import Costs
 from slamd.materials.processing.models.admixture import Admixture
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -7,16 +6,10 @@ from slamd.materials.processing.strategies.base_material_strategy import BaseMat
 class AdmixtureStrategy(BaseMaterialStrategy):
 
     def create_model(self, submitted_material, additional_properties):
-        costs = Costs(
-            co2_footprint=submitted_material['co2_footprint'],
-            delivery_time=submitted_material['delivery_time'],
-            costs=submitted_material['costs']
-        )
-
         admixture = Admixture(
             name=submitted_material['material_name'],
             type=submitted_material['material_type'],
-            costs=costs,
+            costs=self.extract_costs_properties(submitted_material),
             composition=submitted_material['composition'],
             admixture_type=submitted_material['type'],
             additional_properties=additional_properties

--- a/slamd/materials/processing/strategies/admixture_strategy.py
+++ b/slamd/materials/processing/strategies/admixture_strategy.py
@@ -7,10 +7,11 @@ from slamd.materials.processing.strategies.base_material_strategy import BaseMat
 class AdmixtureStrategy(BaseMaterialStrategy):
 
     def create_model(self, submitted_material, additional_properties):
-        costs = Costs()
-        costs.co2_footprint = submitted_material['co2_footprint']
-        costs.delivery_time = submitted_material['delivery_time']
-        costs.costs = submitted_material['costs']
+        costs = Costs(
+            co2_footprint=submitted_material['co2_footprint'],
+            delivery_time=submitted_material['delivery_time'],
+            costs=submitted_material['costs']
+        )
 
         admixture = Admixture(
             name=submitted_material['material_name'],

--- a/slamd/materials/processing/strategies/admixture_strategy.py
+++ b/slamd/materials/processing/strategies/admixture_strategy.py
@@ -12,17 +12,17 @@ class AdmixtureStrategy(BaseMaterialStrategy):
         costs.delivery_time = submitted_material['delivery_time']
         costs.costs = submitted_material['costs']
 
-        admixture = Admixture()
-
-        admixture.name = submitted_material['material_name']
-        admixture.type = submitted_material['material_type']
-        admixture.composition = submitted_material['composition']
-        admixture.type = submitted_material['type']
-        admixture.additional_properties = additional_properties
-        admixture.costs = costs
+        admixture = Admixture(
+            name=submitted_material['material_name'],
+            type=submitted_material['material_type'],
+            costs=costs,
+            composition=submitted_material['composition'],
+            admixture_type=submitted_material['type'],
+            additional_properties=additional_properties
+        )
 
         MaterialsPersistence.save('admixture', admixture)
 
     def _gather_composition_information(self, admixture):
         return [self._include('Composition', admixture.composition),
-                self._include('Type', admixture.type)]
+                self._include('Type', admixture.admixture_type)]

--- a/slamd/materials/processing/strategies/aggregates_strategy.py
+++ b/slamd/materials/processing/strategies/aggregates_strategy.py
@@ -1,4 +1,3 @@
-from slamd.materials.processing.materials_persistence import MaterialsPersistence
 from slamd.materials.processing.models.aggregates import Aggregates, Composition
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -21,7 +20,7 @@ class AggregatesStrategy(BaseMaterialStrategy):
             additional_properties=additional_properties
         )
 
-        MaterialsPersistence.save('aggregates', aggregates)
+        self.save_material(aggregates)
 
     def gather_composition_information(self, aggregates):
         return [self.include('Fine Aggregates', aggregates.composition.fine_aggregates),

--- a/slamd/materials/processing/strategies/aggregates_strategy.py
+++ b/slamd/materials/processing/strategies/aggregates_strategy.py
@@ -18,13 +18,13 @@ class AggregatesStrategy(BaseMaterialStrategy):
         costs.delivery_time = submitted_material['delivery_time']
         costs.costs = submitted_material['costs']
 
-        aggregates = Aggregates()
-
-        aggregates.name = submitted_material['material_name']
-        aggregates.type = submitted_material['material_type']
-        aggregates.costs = costs
-        aggregates.composition = composition
-        aggregates.additional_properties = additional_properties
+        aggregates = Aggregates(
+            name=submitted_material['material_name'],
+            type=submitted_material['material_type'],
+            costs=costs,
+            composition=composition,
+            additional_properties=additional_properties
+        )
 
         MaterialsPersistence.save('aggregates', aggregates)
 

--- a/slamd/materials/processing/strategies/aggregates_strategy.py
+++ b/slamd/materials/processing/strategies/aggregates_strategy.py
@@ -7,11 +7,12 @@ from slamd.materials.processing.strategies.base_material_strategy import BaseMat
 class AggregatesStrategy(BaseMaterialStrategy):
 
     def create_model(self, submitted_material, additional_properties):
-        composition = Composition()
-        composition.fine_aggregates = submitted_material['fine_aggregates']
-        composition.coarse_aggregates = submitted_material['coarse_aggregates']
-        composition.fa_density = submitted_material['fa_density']
-        composition.ca_density = submitted_material['ca_density']
+        composition = Composition(
+            fine_aggregates=submitted_material['fine_aggregates'],
+            coarse_aggregates=submitted_material['coarse_aggregates'],
+            fa_density=submitted_material['fa_density'],
+            ca_density=submitted_material['ca_density']
+        )
 
         costs = Costs()
         costs.co2_footprint = submitted_material['co2_footprint']

--- a/slamd/materials/processing/strategies/aggregates_strategy.py
+++ b/slamd/materials/processing/strategies/aggregates_strategy.py
@@ -30,9 +30,9 @@ class AggregatesStrategy(BaseMaterialStrategy):
 
         MaterialsPersistence.save('aggregates', aggregates)
 
-    def _gather_composition_information(self, aggregates):
-        return [self._include('Fine Aggregates', aggregates.composition.fine_aggregates),
-                self._include('Coarse Aggregates',
-                              aggregates.composition.coarse_aggregates),
-                self._include('FA Density', aggregates.composition.fa_density),
-                self._include('CA Density', aggregates.composition.ca_density)]
+    def gather_composition_information(self, aggregates):
+        return [self.include('Fine Aggregates', aggregates.composition.fine_aggregates),
+                self.include('Coarse Aggregates',
+                             aggregates.composition.coarse_aggregates),
+                self.include('FA Density', aggregates.composition.fa_density),
+                self.include('CA Density', aggregates.composition.ca_density)]

--- a/slamd/materials/processing/strategies/aggregates_strategy.py
+++ b/slamd/materials/processing/strategies/aggregates_strategy.py
@@ -1,5 +1,4 @@
 from slamd.materials.processing.materials_persistence import MaterialsPersistence
-from slamd.materials.processing.models.material import Costs
 from slamd.materials.processing.models.aggregates import Aggregates, Composition
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -14,16 +13,10 @@ class AggregatesStrategy(BaseMaterialStrategy):
             ca_density=submitted_material['ca_density']
         )
 
-        costs = Costs(
-            co2_footprint=submitted_material['co2_footprint'],
-            delivery_time=submitted_material['delivery_time'],
-            costs=submitted_material['costs']
-        )
-
         aggregates = Aggregates(
             name=submitted_material['material_name'],
             type=submitted_material['material_type'],
-            costs=costs,
+            costs=self.extract_costs_properties(submitted_material),
             composition=composition,
             additional_properties=additional_properties
         )

--- a/slamd/materials/processing/strategies/aggregates_strategy.py
+++ b/slamd/materials/processing/strategies/aggregates_strategy.py
@@ -14,10 +14,11 @@ class AggregatesStrategy(BaseMaterialStrategy):
             ca_density=submitted_material['ca_density']
         )
 
-        costs = Costs()
-        costs.co2_footprint = submitted_material['co2_footprint']
-        costs.delivery_time = submitted_material['delivery_time']
-        costs.costs = submitted_material['costs']
+        costs = Costs(
+            co2_footprint=submitted_material['co2_footprint'],
+            delivery_time=submitted_material['delivery_time'],
+            costs=submitted_material['costs']
+        )
 
         aggregates = Aggregates(
             name=submitted_material['material_name'],

--- a/slamd/materials/processing/strategies/base_material_strategy.py
+++ b/slamd/materials/processing/strategies/base_material_strategy.py
@@ -25,10 +25,20 @@ class BaseMaterialStrategy(ABC):
         dto.all_properties = join_all(
             self._gather_composition_information(material))
 
+        self._append_cost_properties(dto, material.costs)
         self._append_additional_properties(dto, material.additional_properties)
         # Remove trailing comma and whitespace
         dto.all_properties = dto.all_properties.strip()[:-1]
         return dto
+
+    def _append_cost_properties(self, dto, costs):
+        if costs is None:
+            return
+        dto.all_properties += self._include('Costs (€/kg)', costs.costs)
+        dto.all_properties += self._include('CO₂ footprint (kg)',
+                                            costs.co2_footprint)
+        dto.all_properties += self._include(
+            'Delivery time (days)', costs.delivery_time)
 
     def _append_additional_properties(self, dto, additional_properties):
         if len(additional_properties) == 0:

--- a/slamd/materials/processing/strategies/base_material_strategy.py
+++ b/slamd/materials/processing/strategies/base_material_strategy.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from slamd.common.slamd_utils import empty
 from slamd.common.slamd_utils import join_all
 from slamd.materials.processing.material_dto import MaterialDto
+from slamd.materials.processing.models.material import Costs
 
 
 class BaseMaterialStrategy(ABC):
@@ -19,6 +20,13 @@ class BaseMaterialStrategy(ABC):
         if empty(property):
             return ''
         return f'{displayed_name}: {property}, '
+
+    def extract_cost_properties(self, submitted_material):
+        return Costs(
+            co2_footprint=submitted_material['co2_footprint'],
+            delivery_time=submitted_material['delivery_time'],
+            costs=submitted_material['costs']
+        )
 
     def create_dto(self, material):
         dto = MaterialDto()

--- a/slamd/materials/processing/strategies/base_material_strategy.py
+++ b/slamd/materials/processing/strategies/base_material_strategy.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from slamd.common.slamd_utils import empty
 from slamd.common.slamd_utils import join_all
 from slamd.materials.processing.material_dto import MaterialDto
+from slamd.materials.processing.materials_persistence import MaterialsPersistence
 from slamd.materials.processing.models.material import Costs
 
 
@@ -15,18 +16,6 @@ class BaseMaterialStrategy(ABC):
     @abstractmethod
     def gather_composition_information(self, material):
         pass
-
-    def include(self, displayed_name, property):
-        if empty(property):
-            return ''
-        return f'{displayed_name}: {property}, '
-
-    def extract_cost_properties(self, submitted_material):
-        return Costs(
-            co2_footprint=submitted_material['co2_footprint'],
-            delivery_time=submitted_material['delivery_time'],
-            costs=submitted_material['costs']
-        )
 
     def create_dto(self, material):
         dto = MaterialDto()
@@ -42,6 +31,22 @@ class BaseMaterialStrategy(ABC):
         # Remove trailing comma and whitespace
         dto.all_properties = dto.all_properties.strip()[:-1]
         return dto
+
+    def extract_cost_properties(self, submitted_material):
+        return Costs(
+            co2_footprint=submitted_material['co2_footprint'],
+            delivery_time=submitted_material['delivery_time'],
+            costs=submitted_material['costs']
+        )
+
+    def include(self, displayed_name, property):
+        if empty(property):
+            return ''
+        return f'{displayed_name}: {property}, '
+
+    def save_material(self, material):
+        material_type = material.type.lower()
+        MaterialsPersistence.save(material_type, material)
 
     def _append_cost_properties(self, dto, costs):
         if costs is None:

--- a/slamd/materials/processing/strategies/base_material_strategy.py
+++ b/slamd/materials/processing/strategies/base_material_strategy.py
@@ -11,7 +11,11 @@ class BaseMaterialStrategy(ABC):
     def create_model(self, submitted_material, additional_properties):
         pass
 
-    def _include(self, displayed_name, property):
+    @abstractmethod
+    def gather_composition_information(self, material):
+        pass
+
+    def include(self, displayed_name, property):
         if empty(property):
             return ''
         return f'{displayed_name}: {property}, '
@@ -23,7 +27,7 @@ class BaseMaterialStrategy(ABC):
         dto.type = material.type
 
         dto.all_properties = join_all(
-            self._gather_composition_information(material))
+            self.gather_composition_information(material))
 
         self._append_cost_properties(dto, material.costs)
         self._append_additional_properties(dto, material.additional_properties)
@@ -34,10 +38,10 @@ class BaseMaterialStrategy(ABC):
     def _append_cost_properties(self, dto, costs):
         if costs is None:
             return
-        dto.all_properties += self._include('Costs (€/kg)', costs.costs)
-        dto.all_properties += self._include('CO₂ footprint (kg)',
-                                            costs.co2_footprint)
-        dto.all_properties += self._include(
+        dto.all_properties += self.include('Costs (€/kg)', costs.costs)
+        dto.all_properties += self.include('CO₂ footprint (kg)',
+                                           costs.co2_footprint)
+        dto.all_properties += self.include(
             'Delivery time (days)', costs.delivery_time)
 
     def _append_additional_properties(self, dto, additional_properties):

--- a/slamd/materials/processing/strategies/base_material_strategy.py
+++ b/slamd/materials/processing/strategies/base_material_strategy.py
@@ -41,7 +41,7 @@ class BaseMaterialStrategy(ABC):
             'Delivery time (days)', costs.delivery_time)
 
     def _append_additional_properties(self, dto, additional_properties):
-        if len(additional_properties) == 0:
+        if additional_properties is None or len(additional_properties) == 0:
             return
 
         additional_property_to_be_displayed = ''

--- a/slamd/materials/processing/strategies/custom_strategy.py
+++ b/slamd/materials/processing/strategies/custom_strategy.py
@@ -7,10 +7,11 @@ from slamd.materials.processing.strategies.base_material_strategy import BaseMat
 class CustomStrategy(BaseMaterialStrategy):
 
     def create_model(self, submitted_material, additional_properties):
-        costs = Costs()
-        costs.co2_footprint = submitted_material['co2_footprint']
-        costs.delivery_time = submitted_material['delivery_time']
-        costs.costs = submitted_material['costs']
+        costs = Costs(
+            co2_footprint=submitted_material['co2_footprint'],
+            delivery_time=submitted_material['delivery_time'],
+            costs=submitted_material['costs']
+        )
 
         custom = Custom(
             name=submitted_material['material_name'],

--- a/slamd/materials/processing/strategies/custom_strategy.py
+++ b/slamd/materials/processing/strategies/custom_strategy.py
@@ -1,4 +1,3 @@
-from slamd.materials.processing.materials_persistence import MaterialsPersistence
 from slamd.materials.processing.models.custom import Custom
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -15,7 +14,7 @@ class CustomStrategy(BaseMaterialStrategy):
             additional_properties=additional_properties
         )
 
-        MaterialsPersistence.save('custom', custom)
+        self.save_material(custom)
 
     def gather_composition_information(self, custom):
         return [self.include('Name', custom.custom_name),

--- a/slamd/materials/processing/strategies/custom_strategy.py
+++ b/slamd/materials/processing/strategies/custom_strategy.py
@@ -24,6 +24,6 @@ class CustomStrategy(BaseMaterialStrategy):
 
         MaterialsPersistence.save('custom', custom)
 
-    def _gather_composition_information(self, custom):
-        return [self._include('Name', custom.custom_name),
-                self._include('Value', custom.custom_value)]
+    def gather_composition_information(self, custom):
+        return [self.include('Name', custom.custom_name),
+                self.include('Value', custom.custom_value)]

--- a/slamd/materials/processing/strategies/custom_strategy.py
+++ b/slamd/materials/processing/strategies/custom_strategy.py
@@ -1,5 +1,4 @@
 from slamd.materials.processing.materials_persistence import MaterialsPersistence
-from slamd.materials.processing.models.material import Costs
 from slamd.materials.processing.models.custom import Custom
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -7,16 +6,10 @@ from slamd.materials.processing.strategies.base_material_strategy import BaseMat
 class CustomStrategy(BaseMaterialStrategy):
 
     def create_model(self, submitted_material, additional_properties):
-        costs = Costs(
-            co2_footprint=submitted_material['co2_footprint'],
-            delivery_time=submitted_material['delivery_time'],
-            costs=submitted_material['costs']
-        )
-
         custom = Custom(
             name=submitted_material['material_name'],
             type=submitted_material['material_type'],
-            costs=costs,
+            costs=self.extract_costs_properties(submitted_material),
             custom_name=submitted_material['name'],
             custom_value=submitted_material['value'],
             additional_properties=additional_properties

--- a/slamd/materials/processing/strategies/custom_strategy.py
+++ b/slamd/materials/processing/strategies/custom_strategy.py
@@ -12,17 +12,17 @@ class CustomStrategy(BaseMaterialStrategy):
         costs.delivery_time = submitted_material['delivery_time']
         costs.costs = submitted_material['costs']
 
-        custom = Custom()
-
-        custom.name = submitted_material['material_name']
-        custom.type = submitted_material['material_type']
-        custom.name = submitted_material['name']
-        custom.value = submitted_material['value']
-        custom.additional_properties = additional_properties
-        custom.costs = costs
+        custom = Custom(
+            name=submitted_material['material_name'],
+            type=submitted_material['material_type'],
+            costs=costs,
+            custom_name=submitted_material['name'],
+            custom_value=submitted_material['value'],
+            additional_properties=additional_properties
+        )
 
         MaterialsPersistence.save('custom', custom)
 
     def _gather_composition_information(self, custom):
-        return [self._include('Name', custom.name),
-                self._include('Vale', custom.value)]
+        return [self._include('Name', custom.custom_name),
+                self._include('Value', custom.custom_value)]

--- a/slamd/materials/processing/strategies/liquid_strategy.py
+++ b/slamd/materials/processing/strategies/liquid_strategy.py
@@ -38,18 +38,18 @@ class LiquidStrategy(BaseMaterialStrategy):
 
         MaterialsPersistence.save('liquid', liquid)
 
-    def _gather_composition_information(self, liquid):
-        return [self._include('Na₂SiO₃', liquid.composition.na2_si_o3),
-                self._include('NaOH', liquid.composition.na_o_h),
-                self._include('Na₂SiO₃ specific',
-                              liquid.composition.na2_si_o3_specific),
-                self._include('NaOH specific',
-                              liquid.composition.na_o_h_specific),
-                self._include('Total solution', liquid.composition.total),
-                self._include('Na₂O', liquid.composition.na2_o),
-                self._include('SiO₂', liquid.composition.si_o2),
-                self._include('H₂O', liquid.composition.h2_o),
-                self._include('Na₂O', liquid.composition.na2_o_dry),
-                self._include('SiO₂', liquid.composition.si_o2_dry),
-                self._include('Water', liquid.composition.water),
-                self._include('Total NaOH', liquid.composition.na_o_h_total)]
+    def gather_composition_information(self, liquid):
+        return [self.include('Na₂SiO₃', liquid.composition.na2_si_o3),
+                self.include('NaOH', liquid.composition.na_o_h),
+                self.include('Na₂SiO₃ specific',
+                             liquid.composition.na2_si_o3_specific),
+                self.include('NaOH specific',
+                             liquid.composition.na_o_h_specific),
+                self.include('Total solution', liquid.composition.total),
+                self.include('Na₂O', liquid.composition.na2_o),
+                self.include('SiO₂', liquid.composition.si_o2),
+                self.include('H₂O', liquid.composition.h2_o),
+                self.include('Na₂O', liquid.composition.na2_o_dry),
+                self.include('SiO₂', liquid.composition.si_o2_dry),
+                self.include('Water', liquid.composition.water),
+                self.include('Total NaOH', liquid.composition.na_o_h_total)]

--- a/slamd/materials/processing/strategies/liquid_strategy.py
+++ b/slamd/materials/processing/strategies/liquid_strategy.py
@@ -7,19 +7,20 @@ from slamd.materials.processing.strategies.base_material_strategy import BaseMat
 class LiquidStrategy(BaseMaterialStrategy):
 
     def create_model(self, submitted_material, additional_properties):
-        composition = Composition()
-        composition.na2_si_o3 = submitted_material['na2_si_o3']
-        composition.na_o_h = submitted_material['na_o_h']
-        composition.na2_si_o3_specific = submitted_material['na2_si_o3_specific']
-        composition.na_o_h_specific = submitted_material['na_o_h_specific']
-        composition.total = submitted_material['total']
-        composition.na2_o = submitted_material['na2_o']
-        composition.si_o2 = submitted_material['si_o2']
-        composition.h2_o = submitted_material['h2_o']
-        composition.na2_o_dry = submitted_material['na2_o_dry']
-        composition.si_o2_dry = submitted_material['si_o2_dry']
-        composition.water = submitted_material['water']
-        composition.na_o_h_total = submitted_material['na_o_h_total']
+        composition = Composition(
+            na2_si_o3=submitted_material['na2_si_o3'],
+            na_o_h=submitted_material['na_o_h'],
+            na2_si_o3_specific=submitted_material['na2_si_o3_specific'],
+            na_o_h_specific=submitted_material['na_o_h_specific'],
+            total=submitted_material['total'],
+            na2_o=submitted_material['na2_o'],
+            si_o2=submitted_material['si_o2'],
+            h2_o=submitted_material['h2_o'],
+            na2_o_dry=submitted_material['na2_o_dry'],
+            si_o2_dry=submitted_material['si_o2_dry'],
+            water=submitted_material['water'],
+            na_o_h_total=submitted_material['na_o_h_total']
+        )
 
         costs = Costs()
         costs.co2_footprint = submitted_material['co2_footprint']

--- a/slamd/materials/processing/strategies/liquid_strategy.py
+++ b/slamd/materials/processing/strategies/liquid_strategy.py
@@ -22,10 +22,11 @@ class LiquidStrategy(BaseMaterialStrategy):
             na_o_h_total=submitted_material['na_o_h_total']
         )
 
-        costs = Costs()
-        costs.co2_footprint = submitted_material['co2_footprint']
-        costs.delivery_time = submitted_material['delivery_time']
-        costs.costs = submitted_material['costs']
+        costs = Costs(
+            co2_footprint=submitted_material['co2_footprint'],
+            delivery_time=submitted_material['delivery_time'],
+            costs=submitted_material['costs']
+        )
 
         liquid = Liquid(
             name=submitted_material['material_name'],

--- a/slamd/materials/processing/strategies/liquid_strategy.py
+++ b/slamd/materials/processing/strategies/liquid_strategy.py
@@ -1,5 +1,4 @@
 from slamd.materials.processing.materials_persistence import MaterialsPersistence
-from slamd.materials.processing.models.material import Costs
 from slamd.materials.processing.models.liquid import Liquid, Composition
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -22,16 +21,10 @@ class LiquidStrategy(BaseMaterialStrategy):
             na_o_h_total=submitted_material['na_o_h_total']
         )
 
-        costs = Costs(
-            co2_footprint=submitted_material['co2_footprint'],
-            delivery_time=submitted_material['delivery_time'],
-            costs=submitted_material['costs']
-        )
-
         liquid = Liquid(
             name=submitted_material['material_name'],
             type=submitted_material['material_type'],
-            costs=costs,
+            costs=self.extract_costs_properties(submitted_material),
             composition=composition,
             additional_properties=additional_properties
         )

--- a/slamd/materials/processing/strategies/liquid_strategy.py
+++ b/slamd/materials/processing/strategies/liquid_strategy.py
@@ -26,13 +26,13 @@ class LiquidStrategy(BaseMaterialStrategy):
         costs.delivery_time = submitted_material['delivery_time']
         costs.costs = submitted_material['costs']
 
-        liquid = Liquid()
-
-        liquid.name = submitted_material['material_name']
-        liquid.type = submitted_material['material_type']
-        liquid.costs = costs
-        liquid.composition = composition
-        liquid.additional_properties = additional_properties
+        liquid = Liquid(
+            name=submitted_material['material_name'],
+            type=submitted_material['material_type'],
+            costs=costs,
+            composition=composition,
+            additional_properties=additional_properties
+        )
 
         MaterialsPersistence.save('liquid', liquid)
 

--- a/slamd/materials/processing/strategies/liquid_strategy.py
+++ b/slamd/materials/processing/strategies/liquid_strategy.py
@@ -1,4 +1,3 @@
-from slamd.materials.processing.materials_persistence import MaterialsPersistence
 from slamd.materials.processing.models.liquid import Liquid, Composition
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -29,7 +28,7 @@ class LiquidStrategy(BaseMaterialStrategy):
             additional_properties=additional_properties
         )
 
-        MaterialsPersistence.save('liquid', liquid)
+        self.save_material(liquid)
 
     def gather_composition_information(self, liquid):
         return [self.include('Na₂SiO₃', liquid.composition.na2_si_o3),

--- a/slamd/materials/processing/strategies/powder_strategy.py
+++ b/slamd/materials/processing/strategies/powder_strategy.py
@@ -7,19 +7,20 @@ from slamd.materials.processing.strategies.base_material_strategy import BaseMat
 class PowderStrategy(BaseMaterialStrategy):
 
     def create_model(self, submitted_material, additional_properties):
-        composition = Composition()
-        composition.fe3_o2 = submitted_material['fe3_o2']
-        composition.si_o2 = submitted_material['si_o2']
-        composition.al2_o3 = submitted_material['al2_o3']
-        composition.ca_o = submitted_material['ca_o']
-        composition.mg_o = submitted_material['mg_o']
-        composition.na2_o = submitted_material['na2_o']
-        composition.k2_o = submitted_material['k2_o']
-        composition.s_o3 = submitted_material['s_o3']
-        composition.ti_o2 = submitted_material['ti_o2']
-        composition.p2_o5 = submitted_material['p2_o5']
-        composition.sr_o = submitted_material['sr_o']
-        composition.mn2_o3 = submitted_material['mn2_o3']
+        composition = Composition(
+            fe3_o2=submitted_material['fe3_o2'],
+            si_o2=submitted_material['si_o2'],
+            al2_o3=submitted_material['al2_o3'],
+            ca_o=submitted_material['ca_o'],
+            mg_o=submitted_material['mg_o'],
+            na2_o=submitted_material['na2_o'],
+            k2_o=submitted_material['k2_o'],
+            s_o3=submitted_material['s_o3'],
+            ti_o2=submitted_material['ti_o2'],
+            p2_o5=submitted_material['p2_o5'],
+            sr_o=submitted_material['sr_o'],
+            mn2_o3=submitted_material['mn2_o3']
+        )
 
         costs = Costs()
         costs.co2_footprint = submitted_material['co2_footprint']

--- a/slamd/materials/processing/strategies/powder_strategy.py
+++ b/slamd/materials/processing/strategies/powder_strategy.py
@@ -22,10 +22,11 @@ class PowderStrategy(BaseMaterialStrategy):
             mn2_o3=submitted_material['mn2_o3']
         )
 
-        costs = Costs()
-        costs.co2_footprint = submitted_material['co2_footprint']
-        costs.delivery_time = submitted_material['delivery_time']
-        costs.costs = submitted_material['costs']
+        costs = Costs(
+            co2_footprint=submitted_material['co2_footprint'],
+            delivery_time=submitted_material['delivery_time'],
+            costs=submitted_material['costs']
+        )
 
         structure = Structure()
         structure.gravity = submitted_material['gravity']

--- a/slamd/materials/processing/strategies/powder_strategy.py
+++ b/slamd/materials/processing/strategies/powder_strategy.py
@@ -30,14 +30,14 @@ class PowderStrategy(BaseMaterialStrategy):
         structure.gravity = submitted_material['gravity']
         structure.fine = submitted_material['fine']
 
-        powder = Powder()
-
-        powder.name = submitted_material['material_name']
-        powder.type = submitted_material['material_type']
-        powder.costs = costs
-        powder.composition = composition
-        powder.structure = structure
-        powder.additional_properties = additional_properties
+        powder = Powder(
+            name=submitted_material['material_name'],
+            type=submitted_material['material_type'],
+            costs=costs,
+            composition=composition,
+            structure=structure,
+            additional_properties=additional_properties
+        )
 
         MaterialsPersistence.save('powder', powder)
 

--- a/slamd/materials/processing/strategies/powder_strategy.py
+++ b/slamd/materials/processing/strategies/powder_strategy.py
@@ -1,5 +1,4 @@
 from slamd.materials.processing.materials_persistence import MaterialsPersistence
-from slamd.materials.processing.models.material import Costs
 from slamd.materials.processing.models.powder import Powder, Composition, Structure
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -22,12 +21,6 @@ class PowderStrategy(BaseMaterialStrategy):
             mn2_o3=submitted_material['mn2_o3']
         )
 
-        costs = Costs(
-            co2_footprint=submitted_material['co2_footprint'],
-            delivery_time=submitted_material['delivery_time'],
-            costs=submitted_material['costs']
-        )
-
         structure = Structure(
             gravity=submitted_material['gravity'],
             fine=submitted_material['fine']
@@ -36,7 +29,7 @@ class PowderStrategy(BaseMaterialStrategy):
         powder = Powder(
             name=submitted_material['material_name'],
             type=submitted_material['material_type'],
-            costs=costs,
+            costs=self.extract_costs_properties(submitted_material),
             composition=composition,
             structure=structure,
             additional_properties=additional_properties

--- a/slamd/materials/processing/strategies/powder_strategy.py
+++ b/slamd/materials/processing/strategies/powder_strategy.py
@@ -44,18 +44,18 @@ class PowderStrategy(BaseMaterialStrategy):
 
         MaterialsPersistence.save('powder', powder)
 
-    def _gather_composition_information(self, powder):
-        return [self._include('Fe₂O₃', powder.composition.fe3_o2),
-                self._include('SiO₂', powder.composition.si_o2),
-                self._include('Al₂O₃', powder.composition.al2_o3),
-                self._include('CaO', powder.composition.ca_o),
-                self._include('MgO', powder.composition.mg_o),
-                self._include('Na₂O', powder.composition.na2_o),
-                self._include('K₂O', powder.composition.k2_o),
-                self._include('SO₃', powder.composition.s_o3),
-                self._include('TiO₂', powder.composition.ti_o2),
-                self._include('P₂O₅', powder.composition.p2_o5),
-                self._include('SrO', powder.composition.sr_o),
-                self._include('Mn₂O₃', powder.composition.mn2_o3),
-                self._include('Fine modules', powder.structure.fine),
-                self._include('Specific gravity', powder.structure.gravity)]
+    def gather_composition_information(self, powder):
+        return [self.include('Fe₂O₃', powder.composition.fe3_o2),
+                self.include('SiO₂', powder.composition.si_o2),
+                self.include('Al₂O₃', powder.composition.al2_o3),
+                self.include('CaO', powder.composition.ca_o),
+                self.include('MgO', powder.composition.mg_o),
+                self.include('Na₂O', powder.composition.na2_o),
+                self.include('K₂O', powder.composition.k2_o),
+                self.include('SO₃', powder.composition.s_o3),
+                self.include('TiO₂', powder.composition.ti_o2),
+                self.include('P₂O₅', powder.composition.p2_o5),
+                self.include('SrO', powder.composition.sr_o),
+                self.include('Mn₂O₃', powder.composition.mn2_o3),
+                self.include('Fine modules', powder.structure.fine),
+                self.include('Specific gravity', powder.structure.gravity)]

--- a/slamd/materials/processing/strategies/powder_strategy.py
+++ b/slamd/materials/processing/strategies/powder_strategy.py
@@ -1,4 +1,3 @@
-from slamd.materials.processing.materials_persistence import MaterialsPersistence
 from slamd.materials.processing.models.powder import Powder, Composition, Structure
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -35,7 +34,7 @@ class PowderStrategy(BaseMaterialStrategy):
             additional_properties=additional_properties
         )
 
-        MaterialsPersistence.save('powder', powder)
+        self.save_material(powder)
 
     def gather_composition_information(self, powder):
         return [self.include('Fe₂O₃', powder.composition.fe3_o2),

--- a/slamd/materials/processing/strategies/powder_strategy.py
+++ b/slamd/materials/processing/strategies/powder_strategy.py
@@ -28,9 +28,10 @@ class PowderStrategy(BaseMaterialStrategy):
             costs=submitted_material['costs']
         )
 
-        structure = Structure()
-        structure.gravity = submitted_material['gravity']
-        structure.fine = submitted_material['fine']
+        structure = Structure(
+            gravity=submitted_material['gravity'],
+            fine=submitted_material['fine']
+        )
 
         powder = Powder(
             name=submitted_material['material_name'],

--- a/slamd/materials/processing/strategies/process_strategy.py
+++ b/slamd/materials/processing/strategies/process_strategy.py
@@ -1,4 +1,3 @@
-from slamd.materials.processing.materials_persistence import MaterialsPersistence
 from slamd.materials.processing.models.process import Process
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -16,7 +15,7 @@ class ProcessStrategy(BaseMaterialStrategy):
             additional_properties=additional_properties
         )
 
-        MaterialsPersistence.save('process', process)
+        self.save_material(process)
 
     def gather_composition_information(self, process):
         return [self.include('Duration', process.duration),

--- a/slamd/materials/processing/strategies/process_strategy.py
+++ b/slamd/materials/processing/strategies/process_strategy.py
@@ -1,5 +1,4 @@
 from slamd.materials.processing.materials_persistence import MaterialsPersistence
-from slamd.materials.processing.models.material import Costs
 from slamd.materials.processing.models.process import Process
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
@@ -7,16 +6,10 @@ from slamd.materials.processing.strategies.base_material_strategy import BaseMat
 class ProcessStrategy(BaseMaterialStrategy):
 
     def create_model(self, submitted_material, additional_properties):
-        costs = Costs(
-            co2_footprint=submitted_material['co2_footprint'],
-            delivery_time=submitted_material['delivery_time'],
-            costs=submitted_material['costs']
-        )
-
         process = Process(
             name=submitted_material['material_name'],
             type=submitted_material['material_type'],
-            costs=costs,
+            costs=self.extract_costs_properties(submitted_material),
             duration=submitted_material['duration'],
             temperature=submitted_material['temperature'],
             relative_humidity=submitted_material['relative_humidity'],

--- a/slamd/materials/processing/strategies/process_strategy.py
+++ b/slamd/materials/processing/strategies/process_strategy.py
@@ -25,7 +25,7 @@ class ProcessStrategy(BaseMaterialStrategy):
 
         MaterialsPersistence.save('process', process)
 
-    def _gather_composition_information(self, process):
-        return [self._include('Duration', process.duration),
-                self._include('Temperature', process.temperature),
-                self._include('Relative Humidity', process.relative_humidity)]
+    def gather_composition_information(self, process):
+        return [self.include('Duration', process.duration),
+                self.include('Temperature', process.temperature),
+                self.include('Relative Humidity', process.relative_humidity)]

--- a/slamd/materials/processing/strategies/process_strategy.py
+++ b/slamd/materials/processing/strategies/process_strategy.py
@@ -12,15 +12,15 @@ class ProcessStrategy(BaseMaterialStrategy):
         costs.delivery_time = submitted_material['delivery_time']
         costs.costs = submitted_material['costs']
 
-        process = Process()
-
-        process.name = submitted_material['material_name']
-        process.type = submitted_material['material_type']
-        process.duration = submitted_material['duration']
-        process.temperature = submitted_material['temperature']
-        process.relative_humidity = submitted_material['relative_humidity']
-        process.additional_properties = additional_properties
-        process.costs = costs
+        process = Process(
+            name=submitted_material['material_name'],
+            type=submitted_material['material_type'],
+            costs=costs,
+            duration=submitted_material['duration'],
+            temperature=submitted_material['temperature'],
+            relative_humidity=submitted_material['relative_humidity'],
+            additional_properties=additional_properties
+        )
 
         MaterialsPersistence.save('process', process)
 

--- a/slamd/materials/processing/strategies/process_strategy.py
+++ b/slamd/materials/processing/strategies/process_strategy.py
@@ -7,10 +7,11 @@ from slamd.materials.processing.strategies.base_material_strategy import BaseMat
 class ProcessStrategy(BaseMaterialStrategy):
 
     def create_model(self, submitted_material, additional_properties):
-        costs = Costs()
-        costs.co2_footprint = submitted_material['co2_footprint']
-        costs.delivery_time = submitted_material['delivery_time']
-        costs.costs = submitted_material['costs']
+        costs = Costs(
+            co2_footprint=submitted_material['co2_footprint'],
+            delivery_time=submitted_material['delivery_time'],
+            costs=submitted_material['costs']
+        )
 
         process = Process(
             name=submitted_material['material_name'],

--- a/tests/common/test_landing_controller.py
+++ b/tests/common/test_landing_controller.py
@@ -4,6 +4,13 @@ def test_slamd_loads(client):
     assert b"SLAMD Dashboard" in response.data
 
 
+def test_slamd_shows_404_page(client):
+    response = client.get("/a_completely_invalid_page", follow_redirects=True)
+
+    assert response.status_code == 404
+    assert b'Not found' in response.data
+
+
 def test_slamd_redirects_materials_page(client):
     response = client.get("/", follow_redirects=True)
 

--- a/tests/materials/materials_test_data.py
+++ b/tests/materials/materials_test_data.py
@@ -1,4 +1,3 @@
-import slamd
 from slamd.materials.processing.models.additional_property import AdditionalProperty
 from slamd.materials.processing.models.aggregates import Aggregates, Composition as AggregatesComposition
 from slamd.materials.processing.models.powder import Composition, Structure, Powder

--- a/tests/materials/materials_test_data.py
+++ b/tests/materials/materials_test_data.py
@@ -1,19 +1,22 @@
 import slamd
 from slamd.materials.processing.models.additional_property import AdditionalProperty
-from slamd.materials.processing.models.aggregates import Aggregates
-from slamd.materials.processing.models.powder import Structure, Powder
+from slamd.materials.processing.models.aggregates import Aggregates, Composition as AggregatesComposition
+from slamd.materials.processing.models.powder import Composition, Structure, Powder
 
 
 def create_test_powders():
-    powder1 = Powder(slamd.materials.processing.models.powder.Composition(fe3_o2='23.3', si_o2=None),
-                     slamd.materials.processing.models.powder.Structure(fine=None, gravity='12'))
+    composition = Composition(fe3_o2='23.3', si_o2=None)
+    structure = Structure(fine=None, gravity='12')
+    powder1 = Powder(composition=composition, structure=structure)
     powder1.uuid = 'test uuid1'
     powder1.name = 'test powder'
     powder1.type = 'Powder'
     powder1.additional_properties = [
         AdditionalProperty(name='test prop', value='test value')]
-    powder2 = Powder(slamd.materials.processing.models.powder.Composition(fe3_o2=None, si_o2=None),
-                     slamd.materials.processing.models.powder.Structure(fine=None, gravity=None))
+
+    composition = Composition(fe3_o2=None, si_o2=None)
+    structure = Structure(fine=None, gravity=None)
+    powder2 = Powder(composition=composition, structure=structure)
     powder2.uuid = 'test uuid2'
     powder2.name = 'my powder'
     powder2.type = 'Powder'
@@ -22,7 +25,8 @@ def create_test_powders():
 
 
 def create_test_aggregates():
-    aggregates = Aggregates(slamd.materials.processing.models.aggregates.Composition(fine_aggregates=12))
+    composition = AggregatesComposition(fine_aggregates=12)
+    aggregates = Aggregates(composition=composition)
     aggregates.uuid = 'test aggregate uuid'
     aggregates.name = 'test aggregate'
     aggregates.type = 'Aggregates'

--- a/tests/materials/materials_test_data.py
+++ b/tests/materials/materials_test_data.py
@@ -7,29 +7,37 @@ from slamd.materials.processing.models.powder import Composition, Structure, Pow
 def create_test_powders():
     composition = Composition(fe3_o2='23.3', si_o2=None)
     structure = Structure(fine=None, gravity='12')
-    powder1 = Powder(composition=composition, structure=structure)
+    powder1 = Powder(
+        name='test powder',
+        type='Powder',
+        composition=composition,
+        structure=structure,
+        additional_properties=[AdditionalProperty(
+            name='test prop', value='test value')]
+    )
     powder1.uuid = 'test uuid1'
-    powder1.name = 'test powder'
-    powder1.type = 'Powder'
-    powder1.additional_properties = [
-        AdditionalProperty(name='test prop', value='test value')]
 
     composition = Composition(fe3_o2=None, si_o2=None)
     structure = Structure(fine=None, gravity=None)
-    powder2 = Powder(composition=composition, structure=structure)
+    powder2 = Powder(
+        name='my powder',
+        type='Powder',
+        composition=composition,
+        structure=structure,
+        additional_properties=[]
+    )
     powder2.uuid = 'test uuid2'
-    powder2.name = 'my powder'
-    powder2.type = 'Powder'
-    powder2.additional_properties = []
     return [powder1, powder2]
 
 
 def create_test_aggregates():
     composition = AggregatesComposition(fine_aggregates=12)
-    aggregates = Aggregates(composition=composition)
+    aggregates = Aggregates(
+        name='test aggregate',
+        type='Aggregates',
+        composition=composition,
+        additional_properties=[AdditionalProperty(
+            name='aggregate property', value='aggregate property value')]
+    )
     aggregates.uuid = 'test aggregate uuid'
-    aggregates.name = 'test aggregate'
-    aggregates.type = 'Aggregates'
-    aggregates.additional_properties = [
-        AdditionalProperty(name='aggregate property', value='aggregate property value')]
     return [aggregates]

--- a/tests/materials/processing/models/test_additional_property.py
+++ b/tests/materials/processing/models/test_additional_property.py
@@ -1,0 +1,16 @@
+from slamd.materials.processing.models.additional_property import AdditionalProperty
+
+
+def test_additional_property_constructor_sets_default_values():
+    additional_property = AdditionalProperty()
+
+    assert additional_property.name == ''
+    assert additional_property.value == ''
+
+
+def test_additional_property_constructor_sets_properties():
+    additional_property = AdditionalProperty(
+        name='test name', value='test value')
+
+    assert additional_property.name == 'test name'
+    assert additional_property.value == 'test value'

--- a/tests/materials/processing/models/test_admixture.py
+++ b/tests/materials/processing/models/test_admixture.py
@@ -1,0 +1,32 @@
+from slamd.materials.processing.models.admixture import Admixture
+from slamd.materials.processing.models.material import Costs
+
+
+def test_admixture_constructor_sets_default_values():
+    admixture = Admixture()
+
+    assert admixture.name == ''
+    assert admixture.type == ''
+    assert admixture.costs == None
+    assert admixture.additional_properties == None
+    assert admixture.composition == None
+    assert admixture.admixture_type == None
+
+
+def test_admixture_constructor_sets_properties():
+    costs = Costs()
+    admixture = Admixture(
+        name='test admixture',
+        type='Admixture',
+        costs=costs,
+        additional_properties='name: test property, value: test value',
+        composition=10.4,
+        admixture_type='test type'
+    )
+
+    assert admixture.name == 'test admixture'
+    assert admixture.type == 'Admixture'
+    assert admixture.costs == costs
+    assert admixture.additional_properties == 'name: test property, value: test value'
+    assert admixture.composition == 10.4
+    assert admixture.admixture_type == 'test type'

--- a/tests/materials/processing/models/test_admixture.py
+++ b/tests/materials/processing/models/test_admixture.py
@@ -8,10 +8,10 @@ def test_admixture_constructor_sets_default_values():
 
     assert admixture.name == ''
     assert admixture.type == ''
-    assert admixture.costs == None
-    assert admixture.additional_properties == None
-    assert admixture.composition == None
-    assert admixture.admixture_type == None
+    assert admixture.costs is None
+    assert admixture.additional_properties is None
+    assert admixture.composition is None
+    assert admixture.admixture_type is None
 
 
 def test_admixture_constructor_sets_properties():

--- a/tests/materials/processing/models/test_admixture.py
+++ b/tests/materials/processing/models/test_admixture.py
@@ -1,3 +1,4 @@
+from slamd.materials.processing.models.additional_property import AdditionalProperty
 from slamd.materials.processing.models.admixture import Admixture
 from slamd.materials.processing.models.material import Costs
 
@@ -19,7 +20,8 @@ def test_admixture_constructor_sets_properties():
         name='test admixture',
         type='Admixture',
         costs=costs,
-        additional_properties='name: test property, value: test value',
+        additional_properties=[AdditionalProperty(
+            name='test prop', value='test value')],
         composition=10.4,
         admixture_type='test type'
     )
@@ -27,6 +29,6 @@ def test_admixture_constructor_sets_properties():
     assert admixture.name == 'test admixture'
     assert admixture.type == 'Admixture'
     assert admixture.costs == costs
-    assert admixture.additional_properties == 'name: test property, value: test value'
+    assert len(admixture.additional_properties) == 1
     assert admixture.composition == 10.4
     assert admixture.admixture_type == 'test type'

--- a/tests/materials/processing/models/test_aggregates.py
+++ b/tests/materials/processing/models/test_aggregates.py
@@ -1,3 +1,4 @@
+from slamd.materials.processing.models.additional_property import AdditionalProperty
 from slamd.materials.processing.models.aggregates import Aggregates, Composition
 from slamd.materials.processing.models.material import Costs
 
@@ -19,14 +20,15 @@ def test_aggregates_constructor_sets_properties():
         name='test aggregates',
         type='Aggregates',
         costs=costs,
-        additional_properties='name: test property, value: test value',
+        additional_properties=[AdditionalProperty(
+            name='test prop', value='test value')],
         composition=composition,
     )
 
     assert aggregates.name == 'test aggregates'
     assert aggregates.type == 'Aggregates'
     assert aggregates.costs == costs
-    assert aggregates.additional_properties == 'name: test property, value: test value'
+    assert len(aggregates.additional_properties) == 1
     assert aggregates.composition == composition
 
 

--- a/tests/materials/processing/models/test_aggregates.py
+++ b/tests/materials/processing/models/test_aggregates.py
@@ -1,0 +1,53 @@
+from slamd.materials.processing.models.aggregates import Aggregates, Composition
+from slamd.materials.processing.models.material import Costs
+
+
+def test_aggregates_constructor_sets_default_values():
+    aggregates = Aggregates()
+
+    assert aggregates.name == ''
+    assert aggregates.type == ''
+    assert aggregates.costs == None
+    assert aggregates.additional_properties == None
+    assert aggregates.composition == None
+
+
+def test_aggregates_constructor_sets_properties():
+    costs = Costs()
+    composition = Composition()
+    aggregates = Aggregates(
+        name='test aggregates',
+        type='Aggregates',
+        costs=costs,
+        additional_properties='name: test property, value: test value',
+        composition=composition,
+    )
+
+    assert aggregates.name == 'test aggregates'
+    assert aggregates.type == 'Aggregates'
+    assert aggregates.costs == costs
+    assert aggregates.additional_properties == 'name: test property, value: test value'
+    assert aggregates.composition == composition
+
+
+def test_aggregates_composition_constructor_sets_default_values():
+    composition = Composition()
+
+    assert composition.fine_aggregates == None
+    assert composition.coarse_aggregates == None
+    assert composition.fa_density == None
+    assert composition.ca_density == None
+
+
+def test_aggregates_composition_constructor_sets_properties():
+    composition = Composition(
+        fine_aggregates=123.45,
+        coarse_aggregates=67.890,
+        fa_density='test FA density',
+        ca_density='test CA density'
+    )
+
+    assert composition.fine_aggregates == 123.45
+    assert composition.coarse_aggregates == 67.890
+    assert composition.fa_density == 'test FA density'
+    assert composition.ca_density == 'test CA density'

--- a/tests/materials/processing/models/test_aggregates.py
+++ b/tests/materials/processing/models/test_aggregates.py
@@ -8,9 +8,9 @@ def test_aggregates_constructor_sets_default_values():
 
     assert aggregates.name == ''
     assert aggregates.type == ''
-    assert aggregates.costs == None
-    assert aggregates.additional_properties == None
-    assert aggregates.composition == None
+    assert aggregates.costs is None
+    assert aggregates.additional_properties is None
+    assert aggregates.composition is None
 
 
 def test_aggregates_constructor_sets_properties():
@@ -35,10 +35,10 @@ def test_aggregates_constructor_sets_properties():
 def test_aggregates_composition_constructor_sets_default_values():
     composition = Composition()
 
-    assert composition.fine_aggregates == None
-    assert composition.coarse_aggregates == None
-    assert composition.fa_density == None
-    assert composition.ca_density == None
+    assert composition.fine_aggregates is None
+    assert composition.coarse_aggregates is None
+    assert composition.fa_density is None
+    assert composition.ca_density is None
 
 
 def test_aggregates_composition_constructor_sets_properties():

--- a/tests/materials/processing/models/test_custom.py
+++ b/tests/materials/processing/models/test_custom.py
@@ -1,3 +1,4 @@
+from slamd.materials.processing.models.additional_property import AdditionalProperty
 from slamd.materials.processing.models.custom import Custom
 from slamd.materials.processing.models.material import Costs
 
@@ -19,7 +20,8 @@ def test_custom_constructor_sets_properties():
         name='test custom',
         type='Custom',
         costs=costs,
-        additional_properties='name: test property, value: test value',
+        additional_properties=[AdditionalProperty(
+            name='test prop', value='test value')],
         custom_name='test custom name',
         custom_value='test custom value'
     )
@@ -27,6 +29,6 @@ def test_custom_constructor_sets_properties():
     assert custom.name == 'test custom'
     assert custom.type == 'Custom'
     assert custom.costs == costs
-    assert custom.additional_properties == 'name: test property, value: test value'
+    assert len(custom.additional_properties) == 1
     assert custom.custom_name == 'test custom name'
     assert custom.custom_value == 'test custom value'

--- a/tests/materials/processing/models/test_custom.py
+++ b/tests/materials/processing/models/test_custom.py
@@ -8,10 +8,10 @@ def test_custom_constructor_sets_default_values():
 
     assert custom.name == ''
     assert custom.type == ''
-    assert custom.costs == None
-    assert custom.additional_properties == None
-    assert custom.custom_name == None
-    assert custom.custom_value == None
+    assert custom.costs is None
+    assert custom.additional_properties is None
+    assert custom.custom_name is None
+    assert custom.custom_value is None
 
 
 def test_custom_constructor_sets_properties():

--- a/tests/materials/processing/models/test_custom.py
+++ b/tests/materials/processing/models/test_custom.py
@@ -1,0 +1,32 @@
+from slamd.materials.processing.models.custom import Custom
+from slamd.materials.processing.models.material import Costs
+
+
+def test_custom_constructor_sets_default_values():
+    custom = Custom()
+
+    assert custom.name == ''
+    assert custom.type == ''
+    assert custom.costs == None
+    assert custom.additional_properties == None
+    assert custom.custom_name == None
+    assert custom.custom_value == None
+
+
+def test_custom_constructor_sets_properties():
+    costs = Costs()
+    custom = Custom(
+        name='test custom',
+        type='Custom',
+        costs=costs,
+        additional_properties='name: test property, value: test value',
+        custom_name='test custom name',
+        custom_value='test custom value'
+    )
+
+    assert custom.name == 'test custom'
+    assert custom.type == 'Custom'
+    assert custom.costs == costs
+    assert custom.additional_properties == 'name: test property, value: test value'
+    assert custom.custom_name == 'test custom name'
+    assert custom.custom_value == 'test custom value'

--- a/tests/materials/processing/models/test_liquid.py
+++ b/tests/materials/processing/models/test_liquid.py
@@ -8,9 +8,9 @@ def test_liquid_constructor_sets_default_values():
 
     assert liquid.name == ''
     assert liquid.type == ''
-    assert liquid.costs == None
-    assert liquid.additional_properties == None
-    assert liquid.composition == None
+    assert liquid.costs is None
+    assert liquid.additional_properties is None
+    assert liquid.composition is None
 
 
 def test_liquid_constructor_sets_properties():
@@ -35,18 +35,18 @@ def test_liquid_constructor_sets_properties():
 def test_liquid_composition_constructor_sets_default_values():
     composition = Composition()
 
-    assert composition.na2_si_o3 == None
-    assert composition.na_o_h == None
-    assert composition.na2_si_o3_specific == None
-    assert composition.na_o_h_specific == None
-    assert composition.total == None
-    assert composition.na2_o == None
-    assert composition.si_o2 == None
-    assert composition.h2_o == None
-    assert composition.na2_o_dry == None
-    assert composition.si_o2_dry == None
-    assert composition.water == None
-    assert composition.na_o_h_total == None
+    assert composition.na2_si_o3 is None
+    assert composition.na_o_h is None
+    assert composition.na2_si_o3_specific is None
+    assert composition.na_o_h_specific is None
+    assert composition.total is None
+    assert composition.na2_o is None
+    assert composition.si_o2 is None
+    assert composition.h2_o is None
+    assert composition.na2_o_dry is None
+    assert composition.si_o2_dry is None
+    assert composition.water is None
+    assert composition.na_o_h_total is None
 
 
 def test_liquid_composition_constructor_sets_properties():

--- a/tests/materials/processing/models/test_liquid.py
+++ b/tests/materials/processing/models/test_liquid.py
@@ -1,0 +1,77 @@
+from slamd.materials.processing.models.liquid import Liquid, Composition
+from slamd.materials.processing.models.material import Costs
+
+
+def test_liquid_constructor_sets_default_values():
+    liquid = Liquid()
+
+    assert liquid.name == ''
+    assert liquid.type == ''
+    assert liquid.costs == None
+    assert liquid.additional_properties == None
+    assert liquid.composition == None
+
+
+def test_liquid_constructor_sets_properties():
+    costs = Costs()
+    composition = Composition()
+    liquid = Liquid(
+        name='test liquid',
+        type='Liquid',
+        costs=costs,
+        additional_properties='name: test property, value: test value',
+        composition=composition,
+    )
+
+    assert liquid.name == 'test liquid'
+    assert liquid.type == 'Liquid'
+    assert liquid.costs == costs
+    assert liquid.additional_properties == 'name: test property, value: test value'
+    assert liquid.composition == composition
+
+
+def test_liquid_composition_constructor_sets_default_values():
+    composition = Composition()
+
+    assert composition.na2_si_o3 == None
+    assert composition.na_o_h == None
+    assert composition.na2_si_o3_specific == None
+    assert composition.na_o_h_specific == None
+    assert composition.total == None
+    assert composition.na2_o == None
+    assert composition.si_o2 == None
+    assert composition.h2_o == None
+    assert composition.na2_o_dry == None
+    assert composition.si_o2_dry == None
+    assert composition.water == None
+    assert composition.na_o_h_total == None
+
+
+def test_liquid_composition_constructor_sets_properties():
+    composition = Composition(
+        na2_si_o3=12.3,
+        na_o_h=23.4,
+        na2_si_o3_specific=34.5,
+        na_o_h_specific=45.6,
+        total=56.7,
+        na2_o=67.8,
+        si_o2=78.9,
+        h2_o=89.0,
+        na2_o_dry=0.98,
+        si_o2_dry=9.87,
+        water=8.76,
+        na_o_h_total=7.65
+    )
+
+    assert composition.na2_si_o3 == 12.3
+    assert composition.na_o_h == 23.4
+    assert composition.na2_si_o3_specific == 34.5
+    assert composition.na_o_h_specific == 45.6
+    assert composition.total == 56.7
+    assert composition.na2_o == 67.8
+    assert composition.si_o2 == 78.9
+    assert composition.h2_o == 89.0
+    assert composition.na2_o_dry == 0.98
+    assert composition.si_o2_dry == 9.87
+    assert composition.water == 8.76
+    assert composition.na_o_h_total == 7.65

--- a/tests/materials/processing/models/test_liquid.py
+++ b/tests/materials/processing/models/test_liquid.py
@@ -1,3 +1,4 @@
+from slamd.materials.processing.models.additional_property import AdditionalProperty
 from slamd.materials.processing.models.liquid import Liquid, Composition
 from slamd.materials.processing.models.material import Costs
 
@@ -19,14 +20,15 @@ def test_liquid_constructor_sets_properties():
         name='test liquid',
         type='Liquid',
         costs=costs,
-        additional_properties='name: test property, value: test value',
+        additional_properties=[AdditionalProperty(
+            name='test prop', value='test value')],
         composition=composition,
     )
 
     assert liquid.name == 'test liquid'
     assert liquid.type == 'Liquid'
     assert liquid.costs == costs
-    assert liquid.additional_properties == 'name: test property, value: test value'
+    assert len(liquid.additional_properties) == 1
     assert liquid.composition == composition
 
 

--- a/tests/materials/processing/models/test_material.py
+++ b/tests/materials/processing/models/test_material.py
@@ -9,7 +9,7 @@ def test_material_constructor_sets_default_values():
     assert material.type == ''
     assert material.costs is None
     assert material.additional_properties is None
-    assert material.is_blended == False
+    assert material.is_blended is False
 
 
 def test_material_constructor_sets_properties():
@@ -27,7 +27,7 @@ def test_material_constructor_sets_properties():
     assert material.type == 'Material'
     assert material.costs == costs
     assert len(material.additional_properties) == 1
-    assert material.is_blended == True
+    assert material.is_blended is True
 
 
 def test_material_constructor_generates_uuid():

--- a/tests/materials/processing/models/test_material.py
+++ b/tests/materials/processing/models/test_material.py
@@ -1,0 +1,61 @@
+from slamd.materials.processing.models.material import Material, Costs
+
+
+def test_material_constructor_sets_default_values():
+    material = Material()
+
+    assert material.name == ''
+    assert material.type == ''
+    assert material.costs == None
+    assert material.additional_properties == None
+    assert material.is_blended == False
+
+
+def test_material_constructor_sets_properties():
+    costs = Costs()
+    material = Material(
+        name='test material',
+        type='Material',
+        costs=costs,
+        additional_properties='name: test property, value: test value',
+        is_blended=True
+    )
+
+    assert material.name == 'test material'
+    assert material.type == 'Material'
+    assert material.costs == costs
+    assert material.additional_properties == 'name: test property, value: test value'
+    assert material.is_blended == True
+
+
+def test_material_constructor_generates_uuid():
+    material = Material()
+
+    assert material.uuid is not None
+
+
+def test_material_constructor_generates_different_uuids():
+    material_1 = Material()
+    material_2 = Material()
+    # This test may fail with an extremely low probability
+    assert material_1.uuid != material_2.uuid
+
+
+def test_material_costs_constructor_sets_default_values():
+    costs = Costs()
+
+    assert costs.delivery_time == 0
+    assert costs.costs == 0
+    assert costs.co2_footprint == 0
+
+
+def test_material_costs_constructor_sets_properties():
+    costs = Costs(
+        delivery_time=12.3,
+        costs=45.6,
+        co2_footprint=78.9
+    )
+
+    assert costs.delivery_time == 12.3
+    assert costs.costs == 45.6
+    assert costs.co2_footprint == 78.9

--- a/tests/materials/processing/models/test_material.py
+++ b/tests/materials/processing/models/test_material.py
@@ -7,8 +7,8 @@ def test_material_constructor_sets_default_values():
 
     assert material.name == ''
     assert material.type == ''
-    assert material.costs == None
-    assert material.additional_properties == None
+    assert material.costs is None
+    assert material.additional_properties is None
     assert material.is_blended == False
 
 

--- a/tests/materials/processing/models/test_material.py
+++ b/tests/materials/processing/models/test_material.py
@@ -1,3 +1,4 @@
+from slamd.materials.processing.models.additional_property import AdditionalProperty
 from slamd.materials.processing.models.material import Material, Costs
 
 
@@ -17,14 +18,15 @@ def test_material_constructor_sets_properties():
         name='test material',
         type='Material',
         costs=costs,
-        additional_properties='name: test property, value: test value',
+        additional_properties=[AdditionalProperty(
+            name='test prop', value='test value')],
         is_blended=True
     )
 
     assert material.name == 'test material'
     assert material.type == 'Material'
     assert material.costs == costs
-    assert material.additional_properties == 'name: test property, value: test value'
+    assert len(material.additional_properties) == 1
     assert material.is_blended == True
 
 

--- a/tests/materials/processing/models/test_powder.py
+++ b/tests/materials/processing/models/test_powder.py
@@ -8,10 +8,10 @@ def test_powder_constructor_sets_default_values():
 
     assert powder.name == ''
     assert powder.type == ''
-    assert powder.costs == None
-    assert powder.additional_properties == None
-    assert powder.composition == None
-    assert powder.structure == None
+    assert powder.costs is None
+    assert powder.additional_properties is None
+    assert powder.composition is None
+    assert powder.structure is None
 
 
 def test_powder_constructor_sets_properties():
@@ -39,18 +39,18 @@ def test_powder_constructor_sets_properties():
 def test_powder_composition_constructor_sets_default_values():
     composition = Composition()
 
-    assert composition.fe3_o2 == None
-    assert composition.si_o2 == None
-    assert composition.al2_o3 == None
-    assert composition.ca_o == None
-    assert composition.mg_o == None
-    assert composition.na2_o == None
-    assert composition.k2_o == None
-    assert composition.s_o3 == None
-    assert composition.ti_o2 == None
-    assert composition.p2_o5 == None
-    assert composition.sr_o == None
-    assert composition.mn2_o3 == None
+    assert composition.fe3_o2 is None
+    assert composition.si_o2 is None
+    assert composition.al2_o3 is None
+    assert composition.ca_o is None
+    assert composition.mg_o is None
+    assert composition.na2_o is None
+    assert composition.k2_o is None
+    assert composition.s_o3 is None
+    assert composition.ti_o2 is None
+    assert composition.p2_o5 is None
+    assert composition.sr_o is None
+    assert composition.mn2_o3 is None
 
 
 def test_powder_composition_constructor_sets_properties():
@@ -86,8 +86,8 @@ def test_powder_composition_constructor_sets_properties():
 def test_powder_structure_constructor_sets_default_values():
     structure = Structure()
 
-    assert structure.fine == None
-    assert structure.gravity == None
+    assert structure.fine is None
+    assert structure.gravity is None
 
 
 def test_powder_structure_constructor_sets_properties():

--- a/tests/materials/processing/models/test_powder.py
+++ b/tests/materials/processing/models/test_powder.py
@@ -1,3 +1,4 @@
+from slamd.materials.processing.models.additional_property import AdditionalProperty
 from slamd.materials.processing.models.powder import Powder, Composition, Structure
 from slamd.materials.processing.models.material import Costs
 
@@ -21,7 +22,8 @@ def test_powder_constructor_sets_properties():
         name='test powder',
         type='Powder',
         costs=costs,
-        additional_properties='name: test property, value: test value',
+        additional_properties=[AdditionalProperty(
+            name='test prop', value='test value')],
         composition=composition,
         structure=structure
     )
@@ -29,7 +31,7 @@ def test_powder_constructor_sets_properties():
     assert powder.name == 'test powder'
     assert powder.type == 'Powder'
     assert powder.costs == costs
-    assert powder.additional_properties == 'name: test property, value: test value'
+    assert len(powder.additional_properties) == 1
     assert powder.composition == composition
     assert powder.structure == structure
 

--- a/tests/materials/processing/models/test_powder.py
+++ b/tests/materials/processing/models/test_powder.py
@@ -1,0 +1,98 @@
+from slamd.materials.processing.models.powder import Powder, Composition, Structure
+from slamd.materials.processing.models.material import Costs
+
+
+def test_powder_constructor_sets_default_values():
+    powder = Powder()
+
+    assert powder.name == ''
+    assert powder.type == ''
+    assert powder.costs == None
+    assert powder.additional_properties == None
+    assert powder.composition == None
+    assert powder.structure == None
+
+
+def test_powder_constructor_sets_properties():
+    costs = Costs()
+    composition = Composition()
+    structure = Structure()
+    powder = Powder(
+        name='test powder',
+        type='Powder',
+        costs=costs,
+        additional_properties='name: test property, value: test value',
+        composition=composition,
+        structure=structure
+    )
+
+    assert powder.name == 'test powder'
+    assert powder.type == 'Powder'
+    assert powder.costs == costs
+    assert powder.additional_properties == 'name: test property, value: test value'
+    assert powder.composition == composition
+    assert powder.structure == structure
+
+
+def test_powder_composition_constructor_sets_default_values():
+    composition = Composition()
+
+    assert composition.fe3_o2 == None
+    assert composition.si_o2 == None
+    assert composition.al2_o3 == None
+    assert composition.ca_o == None
+    assert composition.mg_o == None
+    assert composition.na2_o == None
+    assert composition.k2_o == None
+    assert composition.s_o3 == None
+    assert composition.ti_o2 == None
+    assert composition.p2_o5 == None
+    assert composition.sr_o == None
+    assert composition.mn2_o3 == None
+
+
+def test_powder_composition_constructor_sets_properties():
+    composition = Composition(
+        fe3_o2=12.3,
+        si_o2=23.4,
+        al2_o3=34.5,
+        ca_o=45.6,
+        mg_o=56.7,
+        na2_o=67.8,
+        k2_o=78.9,
+        s_o3=89.0,
+        ti_o2=0.98,
+        p2_o5=9.87,
+        sr_o=8.76,
+        mn2_o3=7.65
+    )
+
+    assert composition.fe3_o2 == 12.3
+    assert composition.si_o2 == 23.4
+    assert composition.al2_o3 == 34.5
+    assert composition.ca_o == 45.6
+    assert composition.mg_o == 56.7
+    assert composition.na2_o == 67.8
+    assert composition.k2_o == 78.9
+    assert composition.s_o3 == 89.0
+    assert composition.ti_o2 == 0.98
+    assert composition.p2_o5 == 9.87
+    assert composition.sr_o == 8.76
+    assert composition.mn2_o3 == 7.65
+
+
+def test_powder_structure_constructor_sets_default_values():
+    structure = Structure()
+
+    assert structure.fine == None
+    assert structure.gravity == None
+
+
+def test_powder_structure_constructor_sets_properties():
+    structure = Structure(
+        fine=123.45,
+        gravity=678.90
+    )
+
+    assert structure.fine == 123.45
+    assert structure.gravity == 678.90

--- a/tests/materials/processing/models/test_process.py
+++ b/tests/materials/processing/models/test_process.py
@@ -1,0 +1,35 @@
+from slamd.materials.processing.models.process import Process
+from slamd.materials.processing.models.material import Costs
+
+
+def test_process_constructor_sets_default_values():
+    process = Process()
+
+    assert process.name == ''
+    assert process.type == ''
+    assert process.costs == None
+    assert process.additional_properties == None
+    assert process.duration == None
+    assert process.temperature == None
+    assert process.relative_humidity == None
+
+
+def test_process_constructor_sets_properties():
+    costs = Costs()
+    process = Process(
+        name='test process',
+        type='Process',
+        costs=costs,
+        additional_properties='name: test property, value: test value',
+        duration=3.21,
+        temperature=6.54,
+        relative_humidity=9.87,
+    )
+
+    assert process.name == 'test process'
+    assert process.type == 'Process'
+    assert process.costs == costs
+    assert process.additional_properties == 'name: test property, value: test value'
+    assert process.duration == 3.21
+    assert process.temperature == 6.54
+    assert process.relative_humidity == 9.87

--- a/tests/materials/processing/models/test_process.py
+++ b/tests/materials/processing/models/test_process.py
@@ -8,11 +8,11 @@ def test_process_constructor_sets_default_values():
 
     assert process.name == ''
     assert process.type == ''
-    assert process.costs == None
-    assert process.additional_properties == None
-    assert process.duration == None
-    assert process.temperature == None
-    assert process.relative_humidity == None
+    assert process.costs is None
+    assert process.additional_properties is None
+    assert process.duration is None
+    assert process.temperature is None
+    assert process.relative_humidity is None
 
 
 def test_process_constructor_sets_properties():

--- a/tests/materials/processing/models/test_process.py
+++ b/tests/materials/processing/models/test_process.py
@@ -1,3 +1,4 @@
+from slamd.materials.processing.models.additional_property import AdditionalProperty
 from slamd.materials.processing.models.process import Process
 from slamd.materials.processing.models.material import Costs
 
@@ -20,7 +21,8 @@ def test_process_constructor_sets_properties():
         name='test process',
         type='Process',
         costs=costs,
-        additional_properties='name: test property, value: test value',
+        additional_properties=[AdditionalProperty(
+            name='test prop', value='test value')],
         duration=3.21,
         temperature=6.54,
         relative_humidity=9.87,
@@ -29,7 +31,7 @@ def test_process_constructor_sets_properties():
     assert process.name == 'test process'
     assert process.type == 'Process'
     assert process.costs == costs
-    assert process.additional_properties == 'name: test property, value: test value'
+    assert len(process.additional_properties) == 1
     assert process.duration == 3.21
     assert process.temperature == 6.54
     assert process.relative_humidity == 9.87

--- a/tests/materials/processing/strategies/test_admixture_strategy.py
+++ b/tests/materials/processing/strategies/test_admixture_strategy.py
@@ -1,0 +1,18 @@
+from slamd.materials.processing.models.admixture import Admixture
+from slamd.materials.processing.models.material import Costs
+from slamd.materials.processing.strategies.admixture_strategy import AdmixtureStrategy
+
+
+def test_gather_composition_properties_adds_all_properties():
+    strategy = AdmixtureStrategy()
+    admixture = Admixture(
+        name='test admixture',
+        type='Admixture',
+        costs=Costs(),
+        additional_properties=[],
+        composition=10.4,
+        admixture_type='test type'
+    )
+    
+    result = strategy.gather_composition_information(admixture)
+    assert result == ['Composition: 10.4, ', 'Type: test type, ']

--- a/tests/materials/processing/strategies/test_aggregates_strategy.py
+++ b/tests/materials/processing/strategies/test_aggregates_strategy.py
@@ -1,0 +1,26 @@
+from slamd.materials.processing.models.aggregates import Aggregates, Composition
+from slamd.materials.processing.models.material import Costs
+from slamd.materials.processing.strategies.aggregates_strategy import AggregatesStrategy
+
+
+def test_gather_composition_properties_adds_all_properties():
+    strategy = AggregatesStrategy()
+    composition = Composition(
+        fine_aggregates=123.45,
+        coarse_aggregates=67.890,
+        fa_density='test FA density',
+        ca_density='test CA density'
+    )
+    aggregates = Aggregates(
+        name='test aggregates',
+        type='Aggregates',
+        costs=Costs(),
+        additional_properties=[],
+        composition=composition,
+    )
+
+    result = strategy.gather_composition_information(aggregates)
+    assert result == ['Fine Aggregates: 123.45, ',
+                      'Coarse Aggregates: 67.89, ',
+                      'FA Density: test FA density, ',
+                      'CA Density: test CA density, ']

--- a/tests/materials/processing/strategies/test_base_material_strategy.py
+++ b/tests/materials/processing/strategies/test_base_material_strategy.py
@@ -1,9 +1,14 @@
+from slamd.materials.processing.material_dto import MaterialDto
+from slamd.materials.processing.models.material import Material
 from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
 
 
 class MockStrategy(BaseMaterialStrategy):
     def create_model(self, submitted_material, additional_properties):
         return None
+
+    def _gather_composition_information(self, material):
+        return
 
 
 def test_base_material_strategy_include_returns_formatted_string():
@@ -26,3 +31,18 @@ def test_base_material_strategy_include_returns_empty_string_if_empty_property()
     result = strategy._include('test name', '')
 
     assert result == ''
+
+
+def test_base_material_strategy_create_dto_without_properties():
+    material = Material(
+        name='test name',
+        type='test type'
+    )
+    strategy = MockStrategy()
+    dto = strategy.create_dto(material)
+
+    assert isinstance(dto, MaterialDto)
+    assert dto.uuid == str(material.uuid)
+    assert dto.name == 'test name'
+    assert dto.type == 'test type'
+    assert dto.all_properties == ''

--- a/tests/materials/processing/strategies/test_base_material_strategy.py
+++ b/tests/materials/processing/strategies/test_base_material_strategy.py
@@ -7,20 +7,20 @@ class MockStrategy(BaseMaterialStrategy):
     def create_model(self, submitted_material, additional_properties):
         return None
 
-    def _gather_composition_information(self, material):
+    def gather_composition_information(self, material):
         return
 
 
 def test_base_material_strategy_include_returns_formatted_string():
     strategy = MockStrategy()
-    result = strategy._include('test name', 'property')
+    result = strategy.include('test name', 'property')
 
     assert result == 'test name: property, '
 
 
 def test_base_material_strategy_include_formats_numbers_with_precision_fifteen():
     strategy = MockStrategy()
-    result = strategy._include('test name', 1.23456789123456789)
+    result = strategy.include('test name', 1.23456789123456789)
 
     # Number is rounded on the 15th decimal digit
     assert result == 'test name: 1.234567891234568, '
@@ -28,7 +28,7 @@ def test_base_material_strategy_include_formats_numbers_with_precision_fifteen()
 
 def test_base_material_strategy_include_returns_empty_string_if_empty_property():
     strategy = MockStrategy()
-    result = strategy._include('test name', '')
+    result = strategy.include('test name', '')
 
     assert result == ''
 

--- a/tests/materials/processing/strategies/test_base_material_strategy.py
+++ b/tests/materials/processing/strategies/test_base_material_strategy.py
@@ -1,0 +1,28 @@
+from slamd.materials.processing.strategies.base_material_strategy import BaseMaterialStrategy
+
+
+class MockStrategy(BaseMaterialStrategy):
+    def create_model(self, submitted_material, additional_properties):
+        return None
+
+
+def test_base_material_strategy_include_returns_formatted_string():
+    strategy = MockStrategy()
+    result = strategy._include('test name', 'property')
+
+    assert result == 'test name: property, '
+
+
+def test_base_material_strategy_include_formats_numbers_with_precision_fifteen():
+    strategy = MockStrategy()
+    result = strategy._include('test name', 1.23456789123456789)
+
+    # Number is rounded on the 15th decimal digit
+    assert result == 'test name: 1.234567891234568, '
+
+
+def test_base_material_strategy_include_returns_empty_string_if_empty_property():
+    strategy = MockStrategy()
+    result = strategy._include('test name', '')
+
+    assert result == ''

--- a/tests/materials/processing/strategies/test_custom_strategy.py
+++ b/tests/materials/processing/strategies/test_custom_strategy.py
@@ -1,0 +1,18 @@
+from slamd.materials.processing.models.custom import Custom
+from slamd.materials.processing.models.material import Costs
+from slamd.materials.processing.strategies.custom_strategy import CustomStrategy
+
+
+def test_gather_composition_properties_adds_all_properties():
+    strategy = CustomStrategy()
+    custom = Custom(
+        name='test custom',
+        type='Custom',
+        costs=Costs(),
+        additional_properties=[],
+        custom_name='test custom name',
+        custom_value='test custom value'
+    )
+
+    result = strategy.gather_composition_information(custom)
+    assert result == ['Name: test custom name, ', 'Value: test custom value, ']

--- a/tests/materials/processing/strategies/test_liquid_strategy.py
+++ b/tests/materials/processing/strategies/test_liquid_strategy.py
@@ -1,0 +1,42 @@
+from slamd.materials.processing.models.liquid import Liquid, Composition
+from slamd.materials.processing.models.material import Costs
+from slamd.materials.processing.strategies.liquid_strategy import LiquidStrategy
+
+
+def test_gather_composition_properties_adds_all_properties():
+    strategy = LiquidStrategy()
+    composition = Composition(
+        na2_si_o3=12.3,
+        na_o_h=23.4,
+        na2_si_o3_specific=34.5,
+        na_o_h_specific=45.6,
+        total=56.7,
+        na2_o=67.8,
+        si_o2=78.9,
+        h2_o=89.0,
+        na2_o_dry=0.98,
+        si_o2_dry=9.87,
+        water=8.76,
+        na_o_h_total=7.65
+    )
+    liquid = Liquid(
+        name='test liquid',
+        type='Liquid',
+        costs=Costs(),
+        additional_properties=[],
+        composition=composition
+    )
+
+    result = strategy.gather_composition_information(liquid)
+    assert result == ['Na₂SiO₃: 12.3, ',
+                      'NaOH: 23.4, ',
+                      'Na₂SiO₃ specific: 34.5, ',
+                      'NaOH specific: 45.6, ',
+                      'Total solution: 56.7, ',
+                      'Na₂O: 67.8, ',
+                      'SiO₂: 78.9, ',
+                      'H₂O: 89.0, ',
+                      'Na₂O: 0.98, ',
+                      'SiO₂: 9.87, ',
+                      'Water: 8.76, ',
+                      'Total NaOH: 7.65, ']

--- a/tests/materials/processing/strategies/test_powder_strategy.py
+++ b/tests/materials/processing/strategies/test_powder_strategy.py
@@ -1,0 +1,49 @@
+from slamd.materials.processing.models.powder import Powder, Structure, Composition
+from slamd.materials.processing.models.material import Costs
+from slamd.materials.processing.strategies.powder_strategy import PowderStrategy
+
+
+def test_gather_composition_properties_adds_all_properties():
+    strategy = PowderStrategy()
+    composition = Composition(
+        fe3_o2=12.3,
+        si_o2=23.4,
+        al2_o3=34.5,
+        ca_o=45.6,
+        mg_o=56.7,
+        na2_o=67.8,
+        k2_o=78.9,
+        s_o3=89.0,
+        ti_o2=0.98,
+        p2_o5=9.87,
+        sr_o=8.76,
+        mn2_o3=7.65
+    )
+    structure = Structure(
+        fine=123.45,
+        gravity=678.90
+    )
+    powder = Powder(
+        name='test powder',
+        type='Powder',
+        costs=Costs(),
+        additional_properties=[],
+        composition=composition,
+        structure=structure
+    )
+
+    result = strategy.gather_composition_information(powder)
+    assert result == ['Fe₂O₃: 12.3, ',
+                      'SiO₂: 23.4, ',
+                      'Al₂O₃: 34.5, ',
+                      'CaO: 45.6, ',
+                      'MgO: 56.7, ',
+                      'Na₂O: 67.8, ',
+                      'K₂O: 78.9, ',
+                      'SO₃: 89.0, ',
+                      'TiO₂: 0.98, ',
+                      'P₂O₅: 9.87, ',
+                      'SrO: 8.76, ',
+                      'Mn₂O₃: 7.65, ',
+                      'Fine modules: 123.45, ',
+                      'Specific gravity: 678.9, ']

--- a/tests/materials/processing/strategies/test_process_strategy.py
+++ b/tests/materials/processing/strategies/test_process_strategy.py
@@ -1,0 +1,20 @@
+from slamd.materials.processing.models.process import Process
+from slamd.materials.processing.models.material import Costs
+from slamd.materials.processing.strategies.process_strategy import ProcessStrategy
+
+
+def test_gather_composition_properties_adds_all_properties():
+    strategy = ProcessStrategy()
+    process = Process(
+        name='test process',
+        type='Process',
+        costs=Costs(),
+        additional_properties=[],
+        duration=3.21,
+        temperature=6.54,
+        relative_humidity=9.87,
+    )
+    
+    result = strategy.gather_composition_information(process)
+    assert result == ['Duration: 3.21, ',
+                      'Temperature: 6.54, ', 'Relative Humidity: 9.87, ']

--- a/tests/materials/processing/test_base_materials_controller.py
+++ b/tests/materials/processing/test_base_materials_controller.py
@@ -12,58 +12,60 @@ def test_slamd_shows_form_and_table(client, mocker):
     mocker.patch.object(BaseMaterialService, 'list_all',
                         autospec=True, return_value=mock_response)
     response = client.get('/materials/base')
+    html = response.data.decode('utf-8')
 
     assert response.status_code == 200
 
-    assert b'Name' in response.data
-    assert b'Material type' in response.data
-    assert bytes('CO₂ footprint', 'utf-8') in response.data
-    assert b'Costs' in response.data
-    assert b'Delivery time' in response.data
+    assert 'Name' in html
+    assert 'Material type' in html
+    assert 'CO₂ footprint' in html
+    assert 'Costs' in html
+    assert 'Delivery time' in html
 
-    assert b'All base materials' in response.data
-    assert b'test powder' in response.data
+    assert 'All base materials' in html
+    assert 'test powder' in html
 
 
 def test_slamd_selects_powder(client):
     response = client.get('/materials/base/powder')
+    template = response.json['template']
 
     assert response.status_code == 200
-    assert 'Fe₂O₃' in response.json['template']
-    assert 'SiO₂' in response.json['template']
-    assert 'Al₂O₃' in response.json['template']
-    assert 'CaO' in response.json['template']
-    assert 'MgO' in response.json['template']
-    assert 'Na₂O' in response.json['template']
-    assert 'K₂O' in response.json['template']
-    assert 'SO₃' in response.json['template']
-    assert 'TiO₂' in response.json['template']
-    assert 'P₂O₅' in response.json['template']
-    assert 'SrO' in response.json['template']
-    assert 'Mn₂O₃' in response.json['template']
+    assert 'Fe₂O₃' in template
+    assert 'SiO₂' in template
+    assert 'Al₂O₃' in template
+    assert 'CaO' in template
+    assert 'MgO' in template
+    assert 'Na₂O' in template
+    assert 'K₂O' in template
+    assert 'SO₃' in template
+    assert 'TiO₂' in template
+    assert 'P₂O₅' in template
+    assert 'SrO' in template
+    assert 'Mn₂O₃' in template
 
 
 def test_slamd_selects_liquid(client):
     response = client.get('/materials/base/liquid')
+    template = response.json['template']
 
     assert response.status_code == 200
-    assert 'Na₂SiO₃' in response.json['template']
-    assert 'NaOH' in response.json['template']
-    assert 'Na₂SiO₃ specific' in response.json['template']
-    assert 'NaOH specific' in response.json['template']
-    assert 'Total solution' in response.json['template']
-    assert 'Na₂O (I)' in response.json['template']
-    assert 'SiO₂ (I)' in response.json['template']
-    assert 'H₂O' in response.json['template']
-    assert 'Na₂O (dry)' in response.json['template']
-    assert 'SiO₂ (dry)' in response.json['template']
-    assert 'Water' in response.json['template']
-    assert 'Total NaOH' in response.json['template']
+    assert 'Na₂SiO₃' in template
+    assert 'NaOH' in template
+    assert 'Na₂SiO₃ specific' in template
+    assert 'NaOH specific' in template
+    assert 'Total solution' in template
+    assert 'Na₂O (I)' in template
+    assert 'SiO₂ (I)' in template
+    assert 'H₂O' in template
+    assert 'Na₂O (dry)' in template
+    assert 'SiO₂ (dry)' in template
+    assert 'Water' in template
+    assert 'Total NaOH' in template
 
 
 def test_slamd_selects_aggregates(client):
     response = client.get('/materials/base/aggregates')
-
     template = response.json['template']
 
     assert response.status_code == 200
@@ -75,7 +77,6 @@ def test_slamd_selects_aggregates(client):
 
 def test_slamd_selects_admixture(client):
     response = client.get('/materials/base/admixture')
-
     template = response.json['template']
 
     assert response.status_code == 200
@@ -85,7 +86,6 @@ def test_slamd_selects_admixture(client):
 
 def test_slamd_selects_custom(client):
     response = client.get("/materials/base/custom")
-
     template = response.json['template']
 
     assert response.status_code == 200
@@ -95,10 +95,9 @@ def test_slamd_selects_custom(client):
 
 def test_slamd_selects_process(client):
     response = client.get('/materials/base/process')
-
     template = response.json['template']
-    assert response.status_code == 200
 
+    assert response.status_code == 200
     assert 'Duration' in template
     assert 'Temperature' in template
     assert 'Relative Humidity' in template
@@ -188,8 +187,8 @@ def test_slamd_deletes_powder_and_returns_new_table_but_does_not_rerender_comple
                         autospec=True, return_value=mock_response)
 
     response = client.delete('/materials/base/powder/123')
-
     template = response.json['template']
+
     assert response.status_code == 200
     assert 'Actions' in template
     assert 'Name' in template

--- a/tests/materials/processing/test_base_materials_service.py
+++ b/tests/materials/processing/test_base_materials_service.py
@@ -72,9 +72,15 @@ def test_create_material_form_raises_bad_request_when_invalid_form_is_requested(
             BaseMaterialService().create_material_form('invalid')
 
 
-def test_save_material_creates_powder(mocker):
-    mocker.patch.object(PowderStrategy, 'create_model',
-                        autospec=True, return_value=None)
+def test_save_material_creates_powder(monkeypatch):
+    mock_create_model_called_with = None
+
+    def mock_create_model(self, submitted_material, additional_properties):
+        nonlocal mock_create_model_called_with
+        mock_create_model_called_with = submitted_material, additional_properties
+        return None
+
+    monkeypatch.setattr(PowderStrategy, 'create_model', mock_create_model)
 
     with app.test_request_context('/materials'):
         form = ImmutableMultiDict([('material_name', 'test powder'),
@@ -99,10 +105,18 @@ def test_save_material_creates_powder(mocker):
                                    ('submit', 'Add material')])
         BaseMaterialService().save_material(form)
 
+    assert mock_create_model_called_with == (form, [])
 
-def test_save_material_creates_liquid(mocker):
-    mocker.patch.object(LiquidStrategy, 'create_model',
-                        autospec=True, return_value=None)
+
+def test_save_material_creates_liquid(monkeypatch):
+    mock_create_model_called_with = None
+
+    def mock_create_model(self, submitted_material, additional_properties):
+        nonlocal mock_create_model_called_with
+        mock_create_model_called_with = submitted_material, additional_properties
+        return None
+
+    monkeypatch.setattr(LiquidStrategy, 'create_model', mock_create_model)
 
     with app.test_request_context('/materials'):
         form = ImmutableMultiDict([('material_name', 'test liquid'),
@@ -122,10 +136,18 @@ def test_save_material_creates_liquid(mocker):
                                    ('submit', 'Add material')])
         BaseMaterialService().save_material(form)
 
+    assert mock_create_model_called_with == (form, [])
 
-def test_save_material_creates_aggregates(mocker):
-    mocker.patch.object(AggregatesStrategy, 'create_model',
-                        autospec=True, return_value=None)
+
+def test_save_material_creates_aggregates(monkeypatch):
+    mock_create_model_called_with = None
+
+    def mock_create_model(self, submitted_material, additional_properties):
+        nonlocal mock_create_model_called_with
+        mock_create_model_called_with = submitted_material, additional_properties
+        return None
+
+    monkeypatch.setattr(AggregatesStrategy, 'create_model', mock_create_model)
 
     with app.test_request_context('/materials'):
         form = ImmutableMultiDict([('material_name', 'test aggregates'),
@@ -137,10 +159,18 @@ def test_save_material_creates_aggregates(mocker):
                                    ('submit', 'Add material')])
         BaseMaterialService().save_material(form)
 
+    assert mock_create_model_called_with == (form, [])
 
-def test_save_material_creates_process(mocker):
-    mocker.patch.object(ProcessStrategy, 'create_model',
-                        autospec=True, return_value=None)
+
+def test_save_material_creates_process(monkeypatch):
+    mock_create_model_called_with = None
+
+    def mock_create_model(self, submitted_material, additional_properties):
+        nonlocal mock_create_model_called_with
+        mock_create_model_called_with = submitted_material, additional_properties
+        return None
+
+    monkeypatch.setattr(ProcessStrategy, 'create_model', mock_create_model)
 
     with app.test_request_context('/materials'):
         form = ImmutableMultiDict([('material_name', 'test process'),
@@ -151,10 +181,18 @@ def test_save_material_creates_process(mocker):
                                    ('submit', 'Add material')])
         BaseMaterialService().save_material(form)
 
+    assert mock_create_model_called_with == (form, [])
 
-def test_save_material_creates_admixture(mocker):
-    mocker.patch.object(AdmixtureStrategy, 'create_model',
-                        autospec=True, return_value=None)
+
+def test_save_material_creates_admixture(monkeypatch):
+    mock_create_model_called_with = None
+
+    def mock_create_model(self, submitted_material, additional_properties):
+        nonlocal mock_create_model_called_with
+        mock_create_model_called_with = submitted_material, additional_properties
+        return None
+
+    monkeypatch.setattr(AdmixtureStrategy, 'create_model', mock_create_model)
 
     with app.test_request_context('/materials'):
         form = ImmutableMultiDict([('material_name', 'test process'),
@@ -163,6 +201,8 @@ def test_save_material_creates_admixture(mocker):
                                    ('type', ''),
                                    ('submit', 'Add material')])
         BaseMaterialService().save_material(form)
+
+    assert mock_create_model_called_with == (form, [])
 
 
 def test_list_all_creates_all_materials_for_view(monkeypatch):

--- a/tests/materials/processing/test_base_materials_service.py
+++ b/tests/materials/processing/test_base_materials_service.py
@@ -72,8 +72,10 @@ def test_create_material_form_raises_bad_request_when_invalid_form_is_requested(
             BaseMaterialService().create_material_form('invalid')
 
 
-@patch.object(PowderStrategy, 'create_model', MagicMock(return_value=None))
-def test_save_material_creates_powder():
+def test_save_material_creates_powder(mocker):
+    mocker.patch.object(PowderStrategy, 'create_model',
+                        autospec=True, return_value=None)
+
     with app.test_request_context('/materials'):
         form = ImmutableMultiDict([('material_name', 'test powder'),
                                    ('material_type', 'Powder'),
@@ -98,8 +100,10 @@ def test_save_material_creates_powder():
         BaseMaterialService().save_material(form)
 
 
-@patch.object(LiquidStrategy, 'create_model', MagicMock(return_value=None))
-def test_save_material_creates_liquid():
+def test_save_material_creates_liquid(mocker):
+    mocker.patch.object(LiquidStrategy, 'create_model',
+                        autospec=True, return_value=None)
+
     with app.test_request_context('/materials'):
         form = ImmutableMultiDict([('material_name', 'test liquid'),
                                    ('material_type', 'Liquid'),
@@ -119,8 +123,10 @@ def test_save_material_creates_liquid():
         BaseMaterialService().save_material(form)
 
 
-@patch.object(AggregatesStrategy, 'create_model', MagicMock(return_value=None))
-def test_save_material_creates_aggregates():
+def test_save_material_creates_aggregates(mocker):
+    mocker.patch.object(AggregatesStrategy, 'create_model',
+                        autospec=True, return_value=None)
+
     with app.test_request_context('/materials'):
         form = ImmutableMultiDict([('material_name', 'test aggregates'),
                                    ('material_type', 'Aggregates'),
@@ -132,8 +138,10 @@ def test_save_material_creates_aggregates():
         BaseMaterialService().save_material(form)
 
 
-@patch.object(ProcessStrategy, 'create_model', MagicMock(return_value=None))
-def test_save_material_creates_process():
+def test_save_material_creates_process(mocker):
+    mocker.patch.object(ProcessStrategy, 'create_model',
+                        autospec=True, return_value=None)
+
     with app.test_request_context('/materials'):
         form = ImmutableMultiDict([('material_name', 'test process'),
                                    ('material_type', 'Process'),
@@ -144,8 +152,10 @@ def test_save_material_creates_process():
         BaseMaterialService().save_material(form)
 
 
-@patch.object(AdmixtureStrategy, 'create_model', MagicMock(return_value=None))
-def test_save_material_creates_admixture():
+def test_save_material_creates_admixture(mocker):
+    mocker.patch.object(AdmixtureStrategy, 'create_model',
+                        autospec=True, return_value=None)
+
     with app.test_request_context('/materials'):
         form = ImmutableMultiDict([('material_name', 'test process'),
                                    ('material_type', 'Admixture'),

--- a/tests/materials/processing/test_base_materials_service.py
+++ b/tests/materials/processing/test_base_materials_service.py
@@ -16,6 +16,7 @@ from slamd.materials.processing.material_type import MaterialType
 from slamd.materials.processing.materials_persistence import MaterialsPersistence
 from slamd.materials.processing.strategies.admixture_strategy import AdmixtureStrategy
 from slamd.materials.processing.strategies.aggregates_strategy import AggregatesStrategy
+from slamd.materials.processing.strategies.custom_strategy import CustomStrategy
 from slamd.materials.processing.strategies.liquid_strategy import LiquidStrategy
 from slamd.materials.processing.strategies.powder_strategy import PowderStrategy
 from slamd.materials.processing.strategies.process_strategy import ProcessStrategy
@@ -195,10 +196,31 @@ def test_save_material_creates_admixture(monkeypatch):
     monkeypatch.setattr(AdmixtureStrategy, 'create_model', mock_create_model)
 
     with app.test_request_context('/materials'):
-        form = ImmutableMultiDict([('material_name', 'test process'),
+        form = ImmutableMultiDict([('material_name', 'test admixture'),
                                    ('material_type', 'Admixture'),
                                    ('composition', ''),
                                    ('type', ''),
+                                   ('submit', 'Add material')])
+        BaseMaterialService().save_material(form)
+
+    assert mock_create_model_called_with == (form, [])
+
+
+def test_save_material_creates_custom(monkeypatch):
+    mock_create_model_called_with = None
+
+    def mock_create_model(self, submitted_material, additional_properties):
+        nonlocal mock_create_model_called_with
+        mock_create_model_called_with = submitted_material, additional_properties
+        return None
+
+    monkeypatch.setattr(CustomStrategy, 'create_model', mock_create_model)
+
+    with app.test_request_context('/materials'):
+        form = ImmutableMultiDict([('material_name', 'test custom'),
+                                   ('material_type', 'Custom'),
+                                   ('custom_name', ''),
+                                   ('custom_value', ''),
                                    ('submit', 'Add material')])
         BaseMaterialService().save_material(form)
 

--- a/tests/materials/processing/test_material_dto.py
+++ b/tests/materials/processing/test_material_dto.py
@@ -1,0 +1,24 @@
+from slamd.materials.processing.material_dto import MaterialDto
+
+
+def test_material_dto_constructor_sets_default_values():
+    material_dto = MaterialDto()
+
+    assert material_dto.uuid == ''
+    assert material_dto.name == ''
+    assert material_dto.type == ''
+    assert material_dto.all_properties == ''
+
+
+def test_material_dto_constructor_sets_properties():
+    material_dto = MaterialDto(
+        uuid='a8098c1a-f86e-11da-bd1a-00112444be1e',
+        name='test material DTO',
+        type='test type',
+        all_properties='prop0: test property, prop1: 12345'
+    )
+
+    assert material_dto.uuid == 'a8098c1a-f86e-11da-bd1a-00112444be1e'
+    assert material_dto.name == 'test material DTO'
+    assert material_dto.type == 'test type'
+    assert material_dto.all_properties == 'prop0: test property, prop1: 12345'


### PR DESCRIPTION
- Show costs properties in table
- Remove annotations for mocking purposes in existing tests
- Use always constructors to create materials, Costs, Structure, Composition, etc.
- Add tests for all models (Powder, Liquid, Aggregates, etc)
- Add tests for MaterialDto
- Add test for 404 page
- Add tests for property formatting in BaseMaterialStrategy

Test coverage is now 91%