### PR TITLE
Slamd 97: Fixing random forest regressor

### DIFF
--- a/slamd/discovery/processing/algorithms/discovery_experiment.py
+++ b/slamd/discovery/processing/algorithms/discovery_experiment.py
@@ -195,6 +195,12 @@ class DiscoveryExperiment:
 
     def fit_random_forest_with_jack_knife_variance_estimators(self):
         for i in range(len(self.targets)):
+            if self.dataframe.loc[:, self.targets[i]].count() <= 1:
+                raise ValueNotSupportedException(message=f'The given dataset does not contain enough training data '
+                                                         f'in column {self.targets[i]}. Please ensure that there are '
+                                                         f'at least 2 data points that are not filtered out by '
+                                                         f'apriori thresholds.')
+
             # Initialize the model
             rfr = RandomForestRegressor()
 

--- a/slamd/discovery/processing/algorithms/discovery_experiment.py
+++ b/slamd/discovery/processing/algorithms/discovery_experiment.py
@@ -211,9 +211,7 @@ class DiscoveryExperiment:
             self._check_target_label_validity(training_labels)
 
             self.x = training_rows
-            # Sum the training labels for all targets
-            # self.y = training_labels.sum(axis=1).to_frame().to_numpy()
-            self.y = training_labels.loc[:,self.targets[i]].to_frame().to_numpy()
+            self.y = training_labels.loc[:, self.targets[i]].to_frame().to_numpy()
             if self.y.shape[0] < 8:
                 self.x = np.tile(self.x, (4, 1))
                 self.y = np.tile(self.y, (4, 1))

--- a/slamd/discovery/processing/algorithms/discovery_experiment.py
+++ b/slamd/discovery/processing/algorithms/discovery_experiment.py
@@ -212,7 +212,8 @@ class DiscoveryExperiment:
 
             self.x = training_rows
             # Sum the training labels for all targets
-            self.y = training_labels.sum(axis=1).to_frame().to_numpy()
+            # self.y = training_labels.sum(axis=1).to_frame().to_numpy()
+            self.y = training_labels.loc[:,self.targets[i]].to_frame().to_numpy()
             if self.y.shape[0] < 8:
                 self.x = np.tile(self.x, (4, 1))
                 self.y = np.tile(self.y, (4, 1))


### PR DESCRIPTION
The RFR trained on the sum of targets rather than the individual targets. This way it produced similar results for every target column, which was incorrect.

In this new version it only trains on the current target, producing results that are in line with preexisting values.

I also added a more descriptive error message for when there are not enough labelled data points.