### PR TITLE
slamd-129: Drop feature name from features list if feature is dropped

### DIFF
--- a/slamd/discovery/processing/experiment/experiment_preprocessor.py
+++ b/slamd/discovery/processing/experiment/experiment_preprocessor.py
@@ -68,6 +68,7 @@ class ExperimentPreprocessor:
         for col in exp.feature_names:
             if exp.dataframe[col].isna().values.any():
                 exp.dataframe.drop(col, axis=1, inplace=True)
+                exp.feature_names.remove(col)
 
     @classmethod
     def filter_apriori_with_thresholds_and_update_orig_data(cls, exp):


### PR DESCRIPTION
Simple issue, simple fix. Although it did raise the question: What do we do if there is missing data in apriori properties?