### PR TITLE
Update discovery_controller.py

### DIFF
--- a/slamd/discovery/processing/discovery_controller.py
+++ b/slamd/discovery/processing/discovery_controller.py
@@ -113,7 +113,7 @@ def download_dataset(dataset):
 def download_prediction():
     filename, dataset_content = DiscoveryService.download_prediction()
     return send_file(dataset_content,
-                     attachment_filename=filename,
+                     download_name=filename,
                      as_attachment=True)
 
 


### PR DESCRIPTION
attachment_filename is deprecated, a new aurgument to specify the file name for the download file: download_name